### PR TITLE
Implement habit reminder service

### DIFF
--- a/V0/lib/reminderService.test.ts
+++ b/V0/lib/reminderService.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { reminderService } from './reminderService'
+import { db, dbUtils } from './db'
+import posthog from 'posthog-js'
+import { toast } from '@/hooks/use-toast'
+
+vi.mock('posthog-js', () => ({
+  default: { capture: vi.fn() }
+}))
+vi.mock('@/hooks/use-toast', () => ({
+  toast: vi.fn()
+}))
+
+const mockedToast = toast as unknown as ReturnType<typeof vi.fn>
+const capture = (posthog as any).default.capture as ReturnType<typeof vi.fn>
+
+describe('reminderService', () => {
+  let userId: number
+
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    capture.mockClear()
+    mockedToast.mockClear()
+    await db.users.clear()
+    userId = await dbUtils.createUser({
+      goal: 'habit',
+      experience: 'beginner',
+      preferredTimes: ['morning'],
+      daysPerWeek: 3,
+      consents: { data: true, gdpr: true, push: true },
+      onboardingComplete: true
+    })
+  })
+
+  afterEach(async () => {
+    reminderService.clear()
+    vi.useRealTimers()
+    await db.users.clear()
+  })
+
+  it('schedules and triggers reminder', async () => {
+    const now = new Date()
+    const inOneMin = new Date(now.getTime() + 60000)
+    const time = `${inOneMin.getHours().toString().padStart(2,'0')}:${inOneMin.getMinutes().toString().padStart(2,'0')}`
+
+    await reminderService.setReminder(time)
+    expect(capture).toHaveBeenCalledWith('reminder_set', { time })
+
+    vi.advanceTimersByTime(60000)
+    await vi.runAllTimers()
+
+    expect(mockedToast).toHaveBeenCalled()
+    expect(capture).toHaveBeenCalledWith('reminder_triggered')
+  })
+
+  it('snoozes reminder', async () => {
+    await reminderService.setReminder('00:00')
+    capture.mockClear()
+    mockedToast.mockClear()
+    await reminderService.snooze(5)
+    expect(capture).toHaveBeenCalledWith('reminder_snoozed', { minutes: 5 })
+    vi.advanceTimersByTime(5 * 60000)
+    await vi.runAllTimers()
+    expect(mockedToast).toHaveBeenCalled()
+  })
+
+  it('disables reminder', async () => {
+    await reminderService.setReminder('00:00')
+    capture.mockClear()
+    mockedToast.mockClear()
+    await reminderService.disableReminder()
+    expect(capture).toHaveBeenCalledWith('reminder_disabled')
+    vi.advanceTimersByTime(24 * 60 * 60000)
+    await vi.runAllTimers()
+    expect(mockedToast).not.toHaveBeenCalled()
+  })
+})

--- a/V0/lib/reminderService.ts
+++ b/V0/lib/reminderService.ts
@@ -1,0 +1,80 @@
+import { dbUtils } from './db'
+import { toast } from '@/hooks/use-toast'
+import posthog from 'posthog-js'
+
+export interface ReminderSettings {
+  time: string
+  enabled: boolean
+  snoozedUntil?: Date | null
+}
+
+class ReminderService {
+  private timeout: ReturnType<typeof setTimeout> | null = null
+
+  async init() {
+    const user = await dbUtils.getCurrentUser()
+    if (!user) return
+    if (user.reminderEnabled && user.reminderTime) {
+      if (user.reminderSnoozedUntil && new Date(user.reminderSnoozedUntil) > new Date()) {
+        const delay = new Date(user.reminderSnoozedUntil).getTime() - Date.now()
+        this.timeout = setTimeout(() => this.trigger(user.id!), delay)
+      } else {
+        this.scheduleNext(user.id!, user.reminderTime)
+      }
+    }
+  }
+
+  clear() {
+    if (this.timeout) {
+      clearTimeout(this.timeout)
+      this.timeout = null
+    }
+  }
+
+  private scheduleNext(userId: number, time: string) {
+    this.clear()
+    const [h, m] = time.split(':').map(Number)
+    const now = new Date()
+    const next = new Date()
+    next.setHours(h, m, 0, 0)
+    if (next <= now) next.setDate(next.getDate() + 1)
+    const delay = next.getTime() - now.getTime()
+    this.timeout = setTimeout(() => this.trigger(userId), delay)
+  }
+
+  private async trigger(userId: number) {
+    toast({ title: 'Time to run!', description: "Let's keep the habit going." })
+    posthog.capture('reminder_triggered')
+    await dbUtils.updateReminderSettings(userId, { reminderSnoozedUntil: null })
+    const settings = await dbUtils.getReminderSettings(userId)
+    if (settings.enabled && settings.time) this.scheduleNext(userId, settings.time)
+  }
+
+  async setReminder(time: string) {
+    const user = await dbUtils.getCurrentUser()
+    if (!user) return
+    await dbUtils.updateReminderSettings(user.id!, { reminderTime: time, reminderEnabled: true, reminderSnoozedUntil: null })
+    posthog.capture('reminder_set', { time })
+    this.scheduleNext(user.id!, time)
+  }
+
+  async disableReminder() {
+    const user = await dbUtils.getCurrentUser()
+    if (!user) return
+    this.clear()
+    await dbUtils.updateReminderSettings(user.id!, { reminderEnabled: false, reminderSnoozedUntil: null })
+    posthog.capture('reminder_disabled')
+  }
+
+  async snooze(minutes: number) {
+    const user = await dbUtils.getCurrentUser()
+    if (!user) return
+    const until = new Date(Date.now() + minutes * 60000)
+    this.clear()
+    await dbUtils.updateReminderSettings(user.id!, { reminderSnoozedUntil: until })
+    posthog.capture('reminder_snoozed', { minutes })
+    this.timeout = setTimeout(() => this.trigger(user.id!), minutes * 60000)
+  }
+}
+
+export const reminderService = new ReminderService()


### PR DESCRIPTION
## Summary
- add reminder fields in Dexie DB
- introduce `reminderService` for scheduling push reminders
- cover reminder logic with unit tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687748f35878832a9258158aafdb7ff4