### PR TITLE
Implement success toast feedback

### DIFF
--- a/V0/components/add-run-modal.test.tsx
+++ b/V0/components/add-run-modal.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { AddRunModal } from './add-run-modal'
+import { useToast } from '@/hooks/use-toast'
+
+vi.mock('@/hooks/use-toast')
+
+describe('AddRunModal', () => {
+  it('shows success toast when workout scheduled', () => {
+    const mockToast = vi.fn()
+    ;(useToast as any).mockReturnValue({ toast: mockToast })
+
+    render(<AddRunModal isOpen={true} onClose={() => {}} />)
+
+    const button = screen.getByText('Schedule Workout')
+    fireEvent.click(button)
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Workout Scheduled! 🎉' })
+    )
+  })
+})

--- a/V0/components/add-run-modal.tsx
+++ b/V0/components/add-run-modal.tsx
@@ -31,6 +31,7 @@ import {
 } from "lucide-react"
 import { generateText } from "ai"
 import { openai } from "@ai-sdk/openai"
+import { useToast } from "@/hooks/use-toast"
 
 interface AddRunModalProps {
   isOpen: boolean
@@ -179,6 +180,7 @@ export function AddRunModal({ isOpen, onClose }: AddRunModalProps) {
   const [selectedDifficulty, setSelectedDifficulty] = useState("open")
   const [generatedWorkout, setGeneratedWorkout] = useState<any>(null)
   const [isGenerating, setIsGenerating] = useState(false)
+  const { toast } = useToast()
 
   const presetDistances = [
     { label: "5k", value: "5.0" },
@@ -309,7 +311,10 @@ export function AddRunModal({ isOpen, onClose }: AddRunModalProps) {
     }
 
     console.log("Saving workout:", workout)
-    alert("Workout added to your plan!")
+    toast({
+      title: "Workout Scheduled! \ud83c\udf89",
+      description: `${selectedWorkout?.name || 'Workout'} added to your plan`,
+    })
 
     // Reset and close
     setStep("select")

--- a/V0/components/ui/toast.test.tsx
+++ b/V0/components/ui/toast.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, act } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { Toaster } from './toaster'
+import { toast } from '@/hooks/use-toast'
+
+describe('toast system', () => {
+  it('renders success toast', async () => {
+    render(<Toaster />)
+
+    act(() => {
+      toast({ title: 'Saved', description: 'Run saved' })
+    })
+
+    expect(await screen.findByText('Saved')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- provide toast feedback when scheduling a workout
- add unit test for add-run-modal toast
- test toast utility directly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687759259360832a84fbefadd56d4543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced browser alert with a toast notification when a workout is scheduled, providing a more modern and user-friendly confirmation message.

* **Tests**
  * Added tests to verify that a success toast appears when a workout is scheduled.
  * Introduced tests for the toast notification system to ensure correct rendering of toast messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->