### PR TITLE
Implement plan complexity engine

### DIFF
--- a/V0/__tests__/plan-complexity-engine.test.ts
+++ b/V0/__tests__/plan-complexity-engine.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { PlanComplexityEngineService } from '@/lib/plan-complexity-engine'
+import type { AdaptationFactor } from '@/lib/db'
+
+
+describe('PlanComplexityEngineService', () => {
+  it('calculates complexity score based on adaptation factors', () => {
+    const factors: AdaptationFactor[] = [
+      { factor: 'performance', weight: 2, currentValue: 8, targetValue: 10 },
+      { factor: 'consistency', weight: 1, currentValue: 5, targetValue: 10 }
+    ]
+    const engine = {
+      userExperience: 'beginner' as const,
+      planLevel: 'basic' as const,
+      adaptationFactors: factors,
+      complexityScore: 0
+    }
+    const updated = PlanComplexityEngineService.updateComplexity(engine)
+    // Expected weighted score: ((8/10)*2 + (5/10)*1)/3 = 0.7 -> 70
+    expect(updated.complexityScore).toBe(70)
+    expect(updated.planLevel).toBe('advanced')
+  })
+})

--- a/V0/__tests__/plan-complexity-indicator.test.tsx
+++ b/V0/__tests__/plan-complexity-indicator.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { PlanComplexityIndicator } from '@/components/plan-complexity-indicator'
+import type { Plan } from '@/lib/db'
+import { describe, it, expect } from 'vitest'
+
+const mockPlan: Plan = {
+  id: 1,
+  userId: 1,
+  title: 'Test Plan',
+  startDate: new Date(),
+  endDate: new Date(),
+  totalWeeks: 4,
+  isActive: true,
+  planType: 'basic',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  complexityLevel: 'standard',
+  complexityScore: 50,
+  adaptationFactors: [
+    { factor: 'performance', weight: 1, currentValue: 5, targetValue: 10 }
+  ]
+}
+
+describe('PlanComplexityIndicator', () => {
+  it('renders complexity level badge and progress', () => {
+    render(<PlanComplexityIndicator plan={mockPlan} />)
+    expect(screen.getByTestId('plan-complexity-indicator')).toBeInTheDocument()
+    expect(screen.getByText('standard')).toBeInTheDocument()
+    const progress = screen.getByTestId('complexity-progress')
+    expect(progress).toBeInTheDocument()
+  })
+})

--- a/V0/components/plan-complexity-indicator.tsx
+++ b/V0/components/plan-complexity-indicator.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { Badge } from '@/components/ui/badge'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import type { Plan } from '@/lib/db'
+import { PlanComplexityEngineService, type PlanComplexityEngine } from '@/lib/plan-complexity-engine'
+
+interface Props {
+  plan: Plan
+  onComplexityChange?: (complexity: PlanComplexityEngine) => void
+}
+
+export function PlanComplexityIndicator({ plan, onComplexityChange }: Props) {
+  const [engineState, setEngineState] = useState<PlanComplexityEngine | null>(null)
+
+  useEffect(() => {
+    const state = PlanComplexityEngineService.initializeFromPlan(plan)
+    const updated = PlanComplexityEngineService.updateComplexity(state)
+    setEngineState(updated)
+    onComplexityChange?.(updated)
+  }, [plan, onComplexityChange])
+
+  if (!engineState) return null
+
+  const { complexityScore, planLevel } = engineState
+
+  const badgeClass = planLevel === 'advanced'
+    ? 'bg-green-100 text-green-800'
+    : planLevel === 'standard'
+      ? 'bg-blue-100 text-blue-800'
+      : 'bg-gray-100 text-gray-800'
+
+  return (
+    <Card className="mb-4" data-testid="plan-complexity-indicator">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium flex items-center gap-2">
+          Plan Complexity <Badge className={badgeClass}>{planLevel}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div data-testid="complexity-progress">
+                <Progress value={complexityScore} />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              Complexity Score: {complexityScore}/100
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  )
+}

--- a/V0/components/plan-screen.tsx
+++ b/V0/components/plan-screen.tsx
@@ -10,6 +10,7 @@ import { MonthlyCalendarView } from "@/components/monthly-calendar-view"
 import { dbUtils, type Plan, type Workout } from "@/lib/db"
 import { useToast } from "@/hooks/use-toast"
 import RecoveryRecommendations from "@/components/recovery-recommendations"
+import { PlanComplexityIndicator } from "@/components/plan-complexity-indicator"
 
 export function PlanScreen() {
   const [currentView, setCurrentView] = useState<"monthly" | "biweekly" | "progress">("biweekly")
@@ -261,6 +262,7 @@ export function PlanScreen() {
         </select>
       </div>
 
+
       {/* Metrics Improvement */}
       <div className="space-y-4">
         {[
@@ -352,6 +354,8 @@ export function PlanScreen() {
           <Plus className="h-4 w-4" />
         </Button>
       </div>
+
+      {plan && <PlanComplexityIndicator plan={plan} />}
 
       {/* View Toggle */}
       <div className="flex bg-gray-100 rounded-lg p-1">

--- a/V0/lib/db.ts
+++ b/V0/lib/db.ts
@@ -440,8 +440,28 @@ export interface Plan {
   fitnessLevel?: 'beginner' | 'intermediate' | 'advanced';
   trainingDaysPerWeek?: number;
   peakWeeklyVolume?: number; // kilometers
+  // Progressive Plan Complexity fields
+  complexityLevel?: 'basic' | 'standard' | 'advanced';
+  complexityScore?: number;
+  adaptationFactors?: AdaptationFactor[];
+  userFeedback?: PlanFeedback[];
   createdAt: Date;
   updatedAt: Date;
+}
+
+export interface AdaptationFactor {
+  factor: 'performance' | 'feedback' | 'consistency' | 'goals';
+  weight: number;
+  currentValue: number;
+  targetValue: number;
+}
+
+export interface PlanFeedback {
+  id?: number;
+  planId: number;
+  rating: number; // 1-5 scale
+  comment?: string;
+  createdAt: Date;
 }
 
 // Individual workout in a plan

--- a/V0/lib/plan-complexity-engine.ts
+++ b/V0/lib/plan-complexity-engine.ts
@@ -1,0 +1,50 @@
+import type { AdaptationFactor } from './db'
+
+export interface PlanComplexityEngine {
+  userExperience: 'beginner' | 'intermediate' | 'advanced';
+  planLevel: 'basic' | 'standard' | 'advanced';
+  adaptationFactors: AdaptationFactor[];
+  complexityScore: number;
+}
+
+export class PlanComplexityEngineService {
+  static initializeFromPlan(plan: { fitnessLevel?: 'beginner' | 'intermediate' | 'advanced'; complexityLevel?: 'basic' | 'standard' | 'advanced'; adaptationFactors?: AdaptationFactor[]; complexityScore?: number; }): PlanComplexityEngine {
+    return {
+      userExperience: plan.fitnessLevel || 'beginner',
+      planLevel: plan.complexityLevel || 'basic',
+      adaptationFactors: plan.adaptationFactors || [],
+      complexityScore: plan.complexityScore || 0
+    }
+  }
+
+  static calculateScore(engine: PlanComplexityEngine): number {
+    const totalWeight = engine.adaptationFactors.reduce((s, f) => s + f.weight, 0)
+    if (totalWeight === 0) return 0
+    const score = engine.adaptationFactors.reduce((sum, f) => {
+      const ratio = f.targetValue === 0 ? 0 : Math.min(f.currentValue / f.targetValue, 1)
+      return sum + ratio * f.weight
+    }, 0)
+    return Math.round((score / totalWeight) * 100)
+  }
+
+  static updateComplexity(engine: PlanComplexityEngine): PlanComplexityEngine {
+    const score = this.calculateScore(engine)
+    let level: 'basic' | 'standard' | 'advanced' = 'basic'
+    if (score >= 66) level = 'advanced'
+    else if (score >= 33) level = 'standard'
+    return { ...engine, complexityScore: score, planLevel: level }
+  }
+
+  static incorporateFeedback(engine: PlanComplexityEngine, rating: number): PlanComplexityEngine {
+    const feedbackFactor: AdaptationFactor = {
+      factor: 'feedback',
+      weight: 1,
+      currentValue: rating,
+      targetValue: 5
+    }
+    const factors = engine.adaptationFactors.filter(f => f.factor !== 'feedback')
+    factors.push(feedbackFactor)
+    const updated = { ...engine, adaptationFactors: factors }
+    return this.updateComplexity(updated)
+  }
+}


### PR DESCRIPTION
## Summary
- add progressive plan complexity fields to db schema
- create plan complexity engine service
- add plan complexity indicator component
- integrate complexity indicator into PlanScreen
- add tests for engine and indicator

## Testing
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688872faea6c832ab2254d1d841fcfde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visual indicator displaying the complexity level and score of fitness plans.
  * Added support for progressive plan complexity, including complexity level, score, adaptation factors, and user feedback.
  * Implemented a complexity engine to assess and update plan complexity based on adaptation factors and feedback.

* **Tests**
  * Added test coverage for the plan complexity engine and the plan complexity indicator component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->