### PR TITLE
fix: re-export dbUtils from db module

### DIFF
--- a/V0/__tests__/advanced-plan-customization.test.tsx
+++ b/V0/__tests__/advanced-plan-customization.test.tsx
@@ -5,14 +5,14 @@ import { PlanCustomizationDashboard } from '../components/plan-customization-das
 import { RaceGoalModal } from '../components/race-goal-modal';
 import { RaceGoalsScreen } from '../components/race-goals-screen';
 import { PeriodizationEngine } from '../lib/periodization';
-import { dbUtils } from '../lib/dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 // Mock global fetch
 global.fetch = vi.fn();
 global.window = { dispatchEvent: vi.fn() } as any;
 
 // Mock dependencies
-vi.mock('../lib/dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   dbUtils: {
     getRaceGoalsByUser: vi.fn(),
     createRaceGoal: vi.fn(),

--- a/V0/__tests__/chat-integration.test.ts
+++ b/V0/__tests__/chat-integration.test.ts
@@ -310,7 +310,7 @@ describe('Chat Integration Tests', () => {
       process.env.OPENAI_API_KEY = 'sk-test-key';
       
       const { generateText } = await import('ai');
-      const { dbUtils } = await import('../lib/dbUtils');
+      const { dbUtils } = await import('@/lib/dbUtils');
       
       vi.mocked(dbUtils.getCurrentUser).mockResolvedValue({
         id: 1,

--- a/V0/__tests__/chatDriver.test.ts
+++ b/V0/__tests__/chatDriver.test.ts
@@ -12,7 +12,7 @@ vi.mock('@ai-sdk/openai', () => ({
 }));
 
 // Mock the database utilities
-vi.mock('../lib/dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   dbUtils: {
     getCurrentUser: vi.fn(),
   },
@@ -136,7 +136,7 @@ describe('ChatDriver', () => {
 
     it('should handle non-streaming request', async () => {
       const { generateText } = await import('ai');
-      const { dbUtils } = await import('../lib/dbUtils');
+      const { dbUtils } = await import('@/lib/dbUtils');
       
       vi.mocked(generateText).mockResolvedValue({
         text: 'Hello! How can I help you?',
@@ -269,7 +269,7 @@ describe('ChatDriver', () => {
 
     it('should include user profile in system message', async () => {
       const { generateText } = await import('ai');
-      const { dbUtils } = await import('../lib/dbUtils');
+      const { dbUtils } = await import('@/lib/dbUtils');
       
       vi.mocked(dbUtils.getCurrentUser).mockResolvedValue({
         id: 1,

--- a/V0/__tests__/db-user-ready.test.ts
+++ b/V0/__tests__/db-user-ready.test.ts
@@ -7,7 +7,7 @@ vi.mock('../lib/db', () => ({
   safeDbOperation: vi.fn()
 }))
 
-import { ensureUserReady, getCurrentUser, performStartupMigration } from '../lib/dbUtils'
+import { ensureUserReady, getCurrentUser, performStartupMigration } from '@/lib/dbUtils'
 import { getDatabase } from '../lib/db'
 
 describe('User Identity Resolution - ensureUserReady', () => {
@@ -182,7 +182,7 @@ describe('getCurrentUser - enhanced with ensureUserReady', () => {
     }
 
     // Mock the entire dbUtils module
-    vi.doMock('../lib/dbUtils', () => ({
+    vi.doMock('@/lib/dbUtils', () => ({
       ensureUserReady: vi.fn().mockResolvedValue(mockUser),
       getCurrentUser: vi.fn().mockResolvedValue(mockUser)
     }))

--- a/V0/__tests__/plan-complexity-engine.test.ts
+++ b/V0/__tests__/plan-complexity-engine.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { planComplexityEngine, PlanComplexityEngineService } from '../lib/plan-complexity-engine';
-import { getCurrentUser, getUserRuns, getPlanWorkouts } from '../lib/dbUtils';
+import { getCurrentUser, getUserRuns, getPlanWorkouts } from '@/lib/dbUtils';
 import type { AdaptationFactor } from '../lib/db';
 
 // Mock the database utilities
-vi.mock('../lib/dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   getCurrentUser: vi.fn(),
   getUserRuns: vi.fn(),
   getPlanWorkouts: vi.fn(),

--- a/V0/__tests__/startup-migration.test.ts
+++ b/V0/__tests__/startup-migration.test.ts
@@ -7,7 +7,7 @@ vi.mock('../lib/db', () => ({
   safeDbOperation: vi.fn()
 }))
 
-import { performStartupMigration } from '../lib/dbUtils'
+import { performStartupMigration } from '@/lib/dbUtils'
 import { getDatabase } from '../lib/db'
 
 describe('Startup Migration', () => {

--- a/V0/__tests__/story-1.5-onboarding-conflict-resolution.test.tsx
+++ b/V0/__tests__/story-1.5-onboarding-conflict-resolution.test.tsx
@@ -3,11 +3,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { OnboardingScreen } from '../components/onboarding-screen';
 import { OnboardingChatOverlay } from '../components/onboarding-chat-overlay';
 import { OnboardingManager } from '../lib/onboardingManager';
-import { dbUtils } from '../lib/dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 import { generatePlan, generateFallbackPlan } from '../lib/planGenerator';
 
 // Mock dependencies
-vi.mock('../lib/dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   dbUtils: {
     getCurrentUser: vi.fn(),
     createUser: vi.fn(),

--- a/V0/app/api/share-run/route.test.ts
+++ b/V0/app/api/share-run/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { POST } from "./route";
 import { NextResponse } from "next/server";
-import * as dbUtilsModule from '../../../lib/dbUtils';
+import * as dbUtilsModule from '@/lib/dbUtils';
 
 describe("POST /api/share-run", () => {
   it("should return a shareable link for a given runId", async () => {

--- a/V0/app/api/share-run/route.ts
+++ b/V0/app/api/share-run/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { dbUtils } from '../../../lib/dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 export async function POST(request: Request) {
   try {

--- a/V0/components/today-screen.test.tsx
+++ b/V0/components/today-screen.test.tsx
@@ -3,10 +3,10 @@ import { vi, MockedFunction } from 'vitest';
 import React from 'react';
 import { TodayScreen } from './today-screen';
 import { StreakIndicator } from "./streak-indicator"
-import { dbUtils } from '../lib/dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 // Mock dbUtils and hooks
-vi.mock('../lib/dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   dbUtils: {
     getCurrentUser: vi.fn(),
     getTodaysWorkout: vi.fn(),

--- a/V0/lib/__tests__/database-initialization.test.ts
+++ b/V0/lib/__tests__/database-initialization.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { isDatabaseAvailable, safeDbOperation, getDatabase } from '../db';
-import { initializeDatabase, getCurrentUser, upsertUser } from '../dbUtils';
+import { initializeDatabase, getCurrentUser, upsertUser } from '@/lib/dbUtils';
 
 // Mock window for testing
 Object.defineProperty(globalThis, 'window', {

--- a/V0/lib/adaptiveCoachingEngine.ts
+++ b/V0/lib/adaptiveCoachingEngine.ts
@@ -2,7 +2,7 @@ import { openai } from '@ai-sdk/openai';
 import { generateObject, generateText } from 'ai';
 import { z } from 'zod';
 import { CoachingProfile, CoachingInteraction, CoachingFeedback } from './db';
-import { dbUtils } from './dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 // Context interfaces
 export interface UserContext {

--- a/V0/lib/db.streak.test.ts
+++ b/V0/lib/db.streak.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { db } from './db';
-import { dbUtils } from './dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 describe('Streak Calculation Engine', () => {
   vi.setConfig({ testTimeout: 30000 });

--- a/V0/lib/db.training-plan.test.ts
+++ b/V0/lib/db.training-plan.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { db } from './db'
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 import FDBFactory from 'fake-indexeddb/lib/FDBFactory'
 
 // Mock IndexedDB

--- a/V0/lib/db.ts
+++ b/V0/lib/db.ts
@@ -1085,6 +1085,10 @@ export const db = new Proxy({} as RunSmartDB, {
   }
 });
 
+// Lazily expose dbUtils to maintain backwards compatibility for modules
+// importing from '@/lib/db' while avoiding eager Dexie initialization.
+export { dbUtils } from './dbUtils';
+
 // Database availability check
 export function isDatabaseAvailable(): boolean {
   if (typeof window === 'undefined') {

--- a/V0/lib/goalProgressEngine.ts
+++ b/V0/lib/goalProgressEngine.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { Goal, GoalMilestone, GoalProgressHistory, Run } from './db';
-import { dbUtils } from './dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 export interface GoalProgress {
   goalId: number;

--- a/V0/lib/onboardingDiagnostics.ts
+++ b/V0/lib/onboardingDiagnostics.ts
@@ -6,7 +6,7 @@
  */
 
 import { type User, db } from './db'
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 
 export interface OnboardingDiagnosticReport {
   indexedDBState: {

--- a/V0/lib/plan-complexity-engine.ts
+++ b/V0/lib/plan-complexity-engine.ts
@@ -1,4 +1,4 @@
-import { getCurrentUser, getUserRuns, getPlanWorkouts } from './dbUtils';
+import { getCurrentUser, getUserRuns, getPlanWorkouts } from '@/lib/dbUtils';
 import { type Plan, type User, type Run, type Workout, type AdaptationFactor } from './db';
 export interface PlanComplexityEngine {
   userExperience: 'beginner' | 'intermediate' | 'advanced';

--- a/V0/lib/planAdaptationEngine.ts
+++ b/V0/lib/planAdaptationEngine.ts
@@ -1,5 +1,5 @@
 import { type User, type Plan, type Run, type Goal } from './db';
-import { dbUtils } from './dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 export interface UserContext {
   goal: 'habit' | 'distance' | 'speed';

--- a/V0/lib/planAdjustmentService.test.ts
+++ b/V0/lib/planAdjustmentService.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { planAdjustmentService } from './planAdjustmentService'
 import { db } from './db'
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 import { generateFallbackPlan } from './planGenerator'
 import { trackPlanAdjustmentEvent } from './analytics'
 
@@ -14,7 +14,7 @@ vi.mock('./db', () => ({
   }
 }))
 
-vi.mock('./dbUtils', () => ({
+vi.mock('@/lib/dbUtils', () => ({
   dbUtils: {
     getActivePlan: vi.fn(),
     updatePlan: vi.fn()

--- a/V0/lib/planAdjustmentService.ts
+++ b/V0/lib/planAdjustmentService.ts
@@ -1,5 +1,5 @@
 import { db, type User } from './db'
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 import { generateFallbackPlan } from './planGenerator'
 import { toast } from '@/hooks/use-toast'
 import { trackPlanAdjustmentEvent } from './analytics'

--- a/V0/lib/planGenerator.test.ts
+++ b/V0/lib/planGenerator.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { db } from './db'
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 import { planAdjustmentService } from './planAdjustmentService'
 import { generateFallbackPlan } from './planGenerator'
 import posthog from 'posthog-js'

--- a/V0/lib/planGenerator.ts
+++ b/V0/lib/planGenerator.ts
@@ -1,5 +1,5 @@
 import { db, type User, type Plan, type Workout } from './db';
-import { dbUtils } from './dbUtils';
+import { dbUtils } from '@/lib/dbUtils';
 
 export interface GeneratePlanOptions {
   user: User;

--- a/V0/lib/reminderService.ts
+++ b/V0/lib/reminderService.ts
@@ -1,4 +1,4 @@
-import { dbUtils } from './dbUtils'
+import { dbUtils } from '@/lib/dbUtils'
 import { toast } from '@/hooks/use-toast'
 import posthog from 'posthog-js'
 import { trackReminderEvent, trackReminderClicked } from './analytics'


### PR DESCRIPTION
## Summary
- expose the dbUtils singleton from lib/db so legacy imports remain valid without reinitializing Dexie
- update app, lib, and test modules to import dbUtils via the shared alias for consistency

## Testing
- npm run dev

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915df38ed8c832a8b9dd63dd1e9e27b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated module import paths from relative to absolute path aliases across library utilities and test files
  * Added re-export for backwards compatibility
  * No changes to application functionality or user-facing features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->