### PR TITLE
Add AI-powered run extraction from activity screenshots

### DIFF
--- a/v0/app/api/ai-activity/route.ts
+++ b/v0/app/api/ai-activity/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server"
+import { generateObject } from "ai"
+import { openai } from "@ai-sdk/openai"
+import { z } from "zod"
+
+export const dynamic = "force-dynamic"
+
+const AiExtractionSchema = z.object({
+  distanceKm: z.number().positive(),
+  durationSeconds: z.number().positive(),
+  paceSecondsPerKm: z.number().positive().optional(),
+  calories: z.number().positive().optional(),
+  notes: z.string().optional(),
+  completedAt: z.string().optional(),
+  type: z.string().optional(),
+})
+
+export async function POST(request: Request) {
+  try {
+    const openaiKey = process.env.OPENAI_API_KEY
+    if (!openaiKey || openaiKey === "your_openai_api_key_here") {
+      return NextResponse.json(
+        { error: "OpenAI API key is not configured." },
+        { status: 503 },
+      )
+    }
+
+    const formData = await request.formData()
+    const file = formData.get("file")
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "No image provided" }, { status: 400 })
+    }
+
+    if (!file.type.startsWith("image/")) {
+      return NextResponse.json({ error: "Only image uploads are supported" }, { status: 400 })
+    }
+
+    if (file.size > 6 * 1024 * 1024) {
+      return NextResponse.json({ error: "Image too large. Please upload a file under 6MB." }, { status: 413 })
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const imagePart = {
+      type: "image" as const,
+      image: new Uint8Array(arrayBuffer),
+      mimeType: file.type || "image/jpeg",
+    }
+
+    const { object } = await generateObject({
+      model: openai("gpt-4o-mini"),
+      temperature: 0.2,
+      schema: AiExtractionSchema,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are an expert running coach. Extract structured run details from workout screenshots.",
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text:
+                "Analyze this workout screenshot and return run data. Use kilometers for distance and seconds for durations. If pace is visible, return seconds per kilometer. Include calories and notes if shown.",
+            },
+            imagePart,
+          ],
+        },
+      ],
+    })
+
+    const parsed = AiExtractionSchema.safeParse(object)
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Unable to parse activity data" }, { status: 422 })
+    }
+
+    return NextResponse.json({ data: parsed.data })
+  } catch (error) {
+    console.error("AI activity extraction failed", error)
+    return NextResponse.json({ error: "Failed to analyze activity image" }, { status: 500 })
+  }
+}

--- a/v0/components/today-screen.tsx
+++ b/v0/components/today-screen.tsx
@@ -752,7 +752,11 @@ export function TodayScreen() {
       {/* Modals */}
       {showAddRunModal && <AddRunModal isOpen={showAddRunModal} onClose={() => setShowAddRunModal(false)} />}
       {showAddActivityModal && (
-        <AddActivityModal isOpen={showAddActivityModal} onClose={() => setShowAddActivityModal(false)} />
+        <AddActivityModal
+          isOpen={showAddActivityModal}
+          onClose={() => setShowAddActivityModal(false)}
+          onSaved={refreshWorkouts}
+        />
       )}
       {showRoutesModal && (
         <RouteSelectorModal

--- a/v0/lib/ai-activity-client.ts
+++ b/v0/lib/ai-activity-client.ts
@@ -1,0 +1,37 @@
+import { z } from "zod"
+
+export const AiActivityResultSchema = z.object({
+  distanceKm: z.number().positive(),
+  durationSeconds: z.number().positive(),
+  paceSecondsPerKm: z.number().positive().optional(),
+  calories: z.number().positive().optional(),
+  notes: z.string().optional(),
+  completedAt: z.string().optional(),
+  type: z.string().optional(),
+})
+
+export type AiActivityResult = z.infer<typeof AiActivityResultSchema>
+
+export async function analyzeActivityImage(file: File): Promise<AiActivityResult> {
+  const formData = new FormData()
+  formData.append("file", file)
+
+  const response = await fetch("/api/ai-activity", {
+    method: "POST",
+    body: formData,
+  })
+
+  const payload = await response.json().catch(() => ({ error: "Invalid response" }))
+
+  if (!response.ok) {
+    const message = typeof payload?.error === "string" ? payload.error : "Unable to analyze image"
+    throw new Error(message)
+  }
+
+  const parsed = AiActivityResultSchema.safeParse(payload?.data ?? payload)
+  if (!parsed.success) {
+    throw new Error("AI response was not in the expected format")
+  }
+
+  return parsed.data
+}


### PR DESCRIPTION
## Summary
- add a dedicated AI activity extraction API to process uploaded workout images
- use the shared client helper in Today’s Add Activity modal to analyze screenshots and save runs automatically
- extend the Manual Run modal with AI upload support while keeping manual entry and save flows intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ee9a499f4832a9a976817bba68082)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered photo upload for activities. Users can now upload images of their runs, and the AI automatically extracts distance, duration, pace, calories, and notes, then saves the activity with a single click.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->