### PR TITLE
feat: add AI photo fill to manual run entry

### DIFF
--- a/v0/app/api/analysis/run-from-photo/route.ts
+++ b/v0/app/api/analysis/run-from-photo/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server"
+import { openai } from "@ai-sdk/openai"
+import { generateObject } from "ai"
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"]
+
+export async function POST(req: Request) {
+  try {
+    const apiKey = process.env.OPENAI_API_KEY
+
+    if (!apiKey) {
+      return NextResponse.json({
+        success: false,
+        error: "OPENAI_API_KEY is not configured. Add it to use AI analysis."
+      }, { status: 503 })
+    }
+
+    const data = await req.formData()
+    const file = data.get("file") as File | null
+
+    if (!file) {
+      return NextResponse.json({ success: false, error: "No file uploaded" }, { status: 400 })
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json({ success: false, error: "Unsupported file type" }, { status: 400 })
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ success: false, error: "File is too large" }, { status: 400 })
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer())
+
+    const result = await generateObject({
+      model: openai("gpt-4o-mini"),
+      schema: {
+        type: "object",
+        properties: {
+          distanceKm: { type: "number" },
+          durationSeconds: { type: "number" },
+          runType: { type: "string" },
+          notes: { type: "string" }
+        },
+        required: ["distanceKm", "durationSeconds", "runType"],
+        additionalProperties: false
+      },
+      prompt: `You are analyzing a photo or screenshot of a running activity. Extract the total distance in kilometers, total duration in seconds, classify the run type (easy, tempo, intervals, long, time-trial, hill, other), and provide any relevant notes to prefill a manual run form. Return concise values only.`,
+      input: [
+        {
+          type: "input_image",
+          image: buffer,
+          mimeType: file.type
+        }
+      ],
+    })
+
+    return NextResponse.json({ success: true, data: result.object })
+  } catch (error) {
+    console.error("Failed to analyze run photo", error)
+    return NextResponse.json({ success: false, error: "Failed to analyze image" }, { status: 500 })
+  }
+}

--- a/v0/components/manual-run-modal.test.tsx
+++ b/v0/components/manual-run-modal.test.tsx
@@ -1,0 +1,91 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ManualRunModal, analyzeRunPhoto, validateManualRunFile } from './manual-run-modal'
+import { dbUtils } from '@/lib/dbUtils'
+import { planAdjustmentService } from '@/lib/planAdjustmentService'
+
+vi.mock('@/lib/db', () => ({
+  resetDatabaseInstance: vi.fn(),
+  db: {}
+}))
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: any) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <div>{children}</div>
+}))
+vi.mock('@/lib/dbUtils')
+vi.mock('@/lib/planAdjustmentService')
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() })
+}))
+
+describe('ManualRunModal AI helpers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns normalized AI response from analyzeRunPhoto', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { distanceKm: 8, durationSeconds: 2400, runType: 'tempo', notes: 'solid' } })
+    })
+    const file = new File(['image'], 'run.jpg', { type: 'image/jpeg' })
+
+    const result = await analyzeRunPhoto(file, mockFetch as any)
+
+    expect(mockFetch).toHaveBeenCalled()
+    expect(result.distanceKm).toBe(8)
+    expect(result.durationSeconds).toBe(2400)
+    expect(result.runType).toBe('tempo')
+    expect(result.notes).toBe('solid')
+  })
+
+  it('validates unsupported files before analysis', async () => {
+    const badFile = new File(['text'], 'note.txt', { type: 'text/plain' })
+
+    await expect(analyzeRunPhoto(badFile, vi.fn() as any)).rejects.toThrow(/Only JPG/)
+  })
+})
+
+describe('ManualRunModal manual overrides', () => {
+  const onClose = vi.fn()
+  const onSaved = vi.fn()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    ;(dbUtils.getCurrentUser as any).mockResolvedValue({ id: 1 })
+    ;(dbUtils.createRun as any).mockResolvedValue(1)
+    ;(dbUtils.markWorkoutCompleted as any).mockResolvedValue(undefined)
+    ;(planAdjustmentService.afterRun as any).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('saves with user edits after AI-prefilled values', async () => {
+    render(<ManualRunModal isOpen onClose={onClose} onSaved={onSaved} />)
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Distance (km)'), { target: { value: '5' } })
+      fireEvent.change(screen.getByLabelText('Duration (MM:SS or HH:MM:SS)'), { target: { value: '30:00' } })
+      fireEvent.change(screen.getByLabelText('Notes (optional)'), { target: { value: 'AI prefill' } })
+    })
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText('Distance (km)'), { target: { value: '7.5' } })
+      fireEvent.change(screen.getByLabelText('Duration (MM:SS or HH:MM:SS)'), { target: { value: '40:00' } })
+      fireEvent.change(screen.getByLabelText('Notes (optional)'), { target: { value: 'User override' } })
+      fireEvent.click(screen.getByRole('button', { name: /save run/i }))
+    })
+
+    expect(dbUtils.createRun).toHaveBeenCalled()
+    const saved = (dbUtils.createRun as any).mock.calls[0][0]
+    expect(saved.distance).toBe(7.5)
+    expect(saved.duration).toBe(2400)
+    expect(saved.notes).toBe('User override')
+    expect(onSaved).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/v0/components/record-screen.tsx
+++ b/v0/components/record-screen.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { ArrowLeft, Map, Play, Pause, Square, Volume2, Satellite, MapPin, AlertTriangle, Info, Loader2, RefreshCw } from "lucide-react"
+import { ArrowLeft, Map, Play, Pause, Square, Volume2, Satellite, MapPin, AlertTriangle, Info, Loader2, RefreshCw, Sparkles } from "lucide-react"
 import { RouteSelectorModal } from "@/components/route-selector-modal"
 import { RouteSelectionWizard } from "@/components/route-selection-wizard"
 import { ManualRunModal } from "@/components/manual-run-modal"
@@ -612,14 +612,22 @@ export function RecordScreen() {
 
             {/* Manual Entry Option */}
             {!isRunning && (
-              <div className="pt-4 border-t">
+              <div className="pt-4 border-t space-y-2">
                 <Button
                   variant="ghost"
                   onClick={() => setShowManualModal(true)}
-                  className="text-gray-600"
+                  className="text-gray-600 w-full"
                 >
                   <Volume2 className="h-4 w-4 mr-2" />
                   Add Manual Run
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowManualModal(true)}
+                  className="w-full"
+                >
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  Upload photo & use AI
                 </Button>
               </div>
             )}


### PR DESCRIPTION
## Summary
- add OpenAI-powered run photo analysis API with validation for missing API keys and file constraints
- extend ManualRunModal with upload controls, inline AI status messaging, and shared helpers
- surface AI upload option on the record screen and cover AI parsing, validation, and manual override flows with tests

## Testing
- `npx vitest run components/manual-run-modal.test.tsx`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692eede80cb0832a9c51801de0754254)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered photo analysis for running workouts. Users can upload workout screenshots (JPEG, PNG, WebP, max 5MB) to automatically extract distance, duration, run type, and notes.
  * Introduced "Upload photo & use AI" button in manual entry section for streamlined activity logging.

* **Tests**
  * Added test suite for photo analysis functionality and user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->