### PR TITLE
fix(plans): enforce single active plan per user

### DIFF
--- a/v0/components/plan-screen.tsx
+++ b/v0/components/plan-screen.tsx
@@ -28,6 +28,7 @@ export function PlanScreen() {
     plan: contextPlan,
     primaryGoal,
     userId,
+    refresh: refreshContext,
   } = useData()
 
   const [currentView, setCurrentView] = useState<"monthly" | "biweekly" | "progress">("monthly")
@@ -128,6 +129,10 @@ export function PlanScreen() {
         challenge: template,
       })
 
+      // Refresh ALL context data (plan, workouts, goals)
+      await refreshContext()
+
+      // Re-fetch local state
       const refreshedPlan = await dbUtils.getActivePlan(userId)
       if (refreshedPlan) {
         setPlan(refreshedPlan)

--- a/v0/lib/challengeEngine.ts
+++ b/v0/lib/challengeEngine.ts
@@ -152,6 +152,15 @@ export async function startChallenge(
       });
     }
 
+    // Deactivate ALL existing active plans for this user
+    await db.plans
+      .where('userId')
+      .equals(userId)
+      .and(plan => plan.isActive)
+      .modify({ isActive: false, updatedAt: new Date() });
+
+    console.log(`[challengeEngine] Deactivated all active plans for user ${userId}`);
+
     // Create new challenge progress
     const progressId = await db.challengeProgress.add({
       userId,
@@ -168,6 +177,7 @@ export async function startChallenge(
 
     try {
       await db.plans.update(planId, {
+        isActive: true,
         isChallenge: true,
         challengeTemplateId: resolvedTemplateId,
         updatedAt: new Date(),


### PR DESCRIPTION
Resolves training plan consistency issues where different screens displayed different workouts for the same day.

Changes:
- challengeEngine.ts: Deactivate all plans when starting challenge, set challenge plan as active
- dbUtils.ts: getTodaysWorkout() now queries only active plan, added fixMultipleActivePlans() migration
- DataContext: Added refreshPlan() to update plan state after changes
- plan-screen.tsx: Call refreshContext() after challenge starts
- page-client.tsx: Run one-time migration on app startup to fix users with multiple active plans

Impact:
- Single source of truth: Only ONE plan can be active per user
- Consistent data: All screens show workouts from the same active plan
- Migration fixes existing users with multiple active plans

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where multiple plans could be active simultaneously. The system now ensures only one plan remains active at a time. When starting a new challenge, previously active plans are automatically deactivated. A one-time migration will run during next startup to resolve any existing instances of this issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->