### PR TITLE
docs: add Session End Rule - nothing stays local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,12 @@ Minimum gate for app changes is usually `npm run lint`, `npm run type-check`, an
 - "Fix this Supabase 406 bug and update lessons if reusable."
 - "Create a QA report for the latest profile changes."
 - "Prepare a PR summary from the spec and QA report."
+
+## Session End Rule: Nothing Stays Local
+
+Every session that produces committed code ends with a push and an open PR (or an explicit handoff) before declaring done. No exceptions. This applies to Claude Code, Codex, and Cursor alike.
+
+1. Before declaring done, run `git status --short --branch` and `git log --oneline @{u}..` and report the output in the final message.
+2. If you cannot push or open a PR, end with exactly: "N commits are local-only on branch X - you need to push and open a PR."
+3. Never leave work in a worktree without reporting the worktree path and branch in the final message.
+4. Safety net: the Agentic OS Stranded Work board (`./agentic-os refresh`, then PROJECT-STATUS.md) lists every unpushed branch, local-only commit, and leftover worktree across all projects. It runs as part of the morning brief.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,12 @@ Follow `AGENTS.md`.
 - Update `tasks/lessons.md` after mistakes, user corrections, failed assumptions, broken tests, or repeated issues.
 - Work in small, verified steps and complete one story before starting another.
 - Verify before done and report commands/checks run.
+
+## Session End Rule: Nothing Stays Local
+
+Every session that produces committed code ends with a push and an open PR (or an explicit handoff) before declaring done. No exceptions. This applies to Claude Code, Codex, and Cursor alike.
+
+1. Before declaring done, run `git status --short --branch` and `git log --oneline @{u}..` and report the output in the final message.
+2. If you cannot push or open a PR, end with exactly: "N commits are local-only on branch X - you need to push and open a PR."
+3. Never leave work in a worktree without reporting the worktree path and branch in the final message.
+4. Safety net: the Agentic OS Stranded Work board (`./agentic-os refresh`, then PROJECT-STATUS.md) lists every unpushed branch, local-only commit, and leftover worktree across all projects. It runs as part of the morning brief.


### PR DESCRIPTION
## Summary
- Adds the Session End Rule to AGENTS.md and CLAUDE.md: every code-producing session ends with a push and an open PR (or an explicit local-only handoff report) before declaring done
- Applies identically to Claude Code, Codex, and Cursor
- Points to the Agentic OS Stranded Work board as the cross-repo safety net

Docs only, no app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)