### PR TITLE
feat: Aha Moments Phase 1-3 — onboarding, post-run achievement, noticed coaching

### DIFF
--- a/docs/agent-os/work-packets/aha-moments-phase2-phase3.md
+++ b/docs/agent-os/work-packets/aha-moments-phase2-phase3.md
@@ -1,0 +1,561 @@
+# Work Packet — Aha Moments Phase 2 + Phase 3
+
+**Goal:** Complete the RunSmart Aha Moment system by implementing Moment #2 (first-run / personal-best achievement overlay) and Moment #4 ("Someone noticed" — context-aware inline card), plus the shared DB persistence layer.
+
+**Use `superpowers:subagent-driven-development` to execute this plan task-by-task.**
+
+---
+
+## What Phase 1 Already Built
+
+These files exist and MUST NOT be reimplemented. Read them before writing anything new.
+
+| File | What it does |
+|------|-------------|
+| `v0/lib/userInsightService.ts` | Pure functions: `getRunningIdentity()`, `projectGoalTimeline()` |
+| `v0/components/aha-moment-overlay.tsx` | Reusable full-screen overlay shell (used by Moments #1 and #3) |
+| `v0/components/runner-identity-moment.tsx` | Moment #1: identity badge shown after onboarding |
+| `v0/components/goal-timeline-moment.tsx` | Moment #3: goal timeline shown after onboarding |
+| `v0/components/onboarding-screen.tsx` | Wires Moments #1 and #3; intercepts `onComplete()` |
+| `v0/lib/analytics.ts` | `trackOnboardingEvent()` — fire-and-forget PostHog wrapper |
+
+**Pattern established by Phase 1:**
+- Components receive pre-computed data as props — no async inside moment components
+- PostHog events: `aha_moment_fired`, `aha_moment_cta_clicked`, `aha_moment_dismissed`
+- Fire-and-forget analytics: `void trackEvent(...)` before navigation calls
+- Tests use vitest + @testing-library/react; mock `@/lib/analytics` with `vi.mock`
+
+---
+
+## Rollout Order (from AHA_MOMENTS.md)
+
+```
+Phase 1 ✅  Moments #1 + #3  (onboarding, no run data required)
+Phase 2 👈  Moment #2        (post-run achievement, requires run data)
+            + DB persistence layer
+Phase 3 👈  Moment #4        (context-aware inline card, recurring)
+            + AhaMomentEngine orchestrator
+```
+
+**Gate:** Phase 3 builds on Phase 2. Complete and test Phase 2 fully before starting Phase 3.
+
+---
+
+## Existing Files to Read Before Modifying
+
+| File | Why |
+|------|-----|
+| `v0/components/record-screen.tsx:2332` | `saveRun()` — where run is persisted; `finalizePostRunFlow(runId)` triggers navigation |
+| `v0/components/record-screen.tsx:2558` | `finalizePostRunFlow()` — calls `navigateToRunReport(runId)` |
+| `v0/app/runs/[id]/report/page.tsx` (or `v0/app/activities/[id]/page.tsx`) | Run report page — where Moment #4 card injects |
+| `v0/lib/dbUtils.ts` | DB helper patterns — follow existing style for new helpers |
+| `v0/components/insights/PostRunRecap.tsx` | Reference for how post-run data is consumed |
+
+---
+
+## Phase 2 — Moment #2 "I just did something I didn't think I could"
+
+### Trigger logic
+
+**Fires before** `finalizePostRunFlow(runId)` in `record-screen.tsx`.
+
+Conditions (check in order; first true wins):
+1. **First run ever** — `SELECT COUNT(*) FROM runs WHERE user_id = $1` returns 0 before the current run is inserted. Use `count` from `recordRunWithSideEffects` return value if available, or query after save.
+2. **New personal best distance** — `current_distance_km > MAX(distance_km) FROM runs WHERE user_id = $1 AND id != $currentRunId`
+3. **Milestone crossed** — first run ≥ 5.0 km, ≥ 10.0 km, or ≥ 21.1 km (check against prior run history)
+
+If no condition is true: skip the moment, proceed directly to `finalizePostRunFlow`.
+
+### New files
+
+#### `v0/lib/achievementDetector.ts`
+
+Pure async function — no side effects, easily testable.
+
+```typescript
+import { supabase } from '@/lib/supabase'
+
+export type AchievementContext =
+  | { type: 'first_run'; distanceKm: number }
+  | { type: 'personal_best'; distanceKm: number; previousBestKm: number }
+  | { type: 'milestone'; distanceKm: number; milestoneKm: 5 | 10 | 21.1 }
+
+const MILESTONES: Array<5 | 10 | 21.1> = [5, 10, 21.1]
+
+export async function detectAchievement(
+  userId: string,
+  currentRunId: number,
+  currentDistanceKm: number
+): Promise<AchievementContext | null> {
+  const { data: prior } = await supabase
+    .from('runs')
+    .select('distance_km')
+    .eq('user_id', userId)
+    .neq('id', currentRunId)
+    .order('distance_km', { ascending: false })
+    .limit(1)
+    .single()
+
+  // First run
+  if (!prior) {
+    return { type: 'first_run', distanceKm: currentDistanceKm }
+  }
+
+  // Milestone
+  for (const milestone of MILESTONES) {
+    if (currentDistanceKm >= milestone && prior.distance_km < milestone) {
+      return { type: 'milestone', distanceKm: currentDistanceKm, milestoneKm: milestone }
+    }
+  }
+
+  // Personal best
+  if (currentDistanceKm > prior.distance_km) {
+    return {
+      type: 'personal_best',
+      distanceKm: currentDistanceKm,
+      previousBestKm: prior.distance_km,
+    }
+  }
+
+  return null
+}
+```
+
+#### `v0/lib/achievementDetector.test.ts`
+
+Mock `@/lib/supabase`. Test all 4 branches: first run, milestone, personal best, no achievement. At minimum:
+- `first_run` when prior query returns null
+- `milestone` when prior.distance_km = 4.5, current = 5.1 → returns `{ type: 'milestone', milestoneKm: 5 }`
+- `personal_best` when prior.distance_km = 4.0, current = 4.5
+- `null` when current < prior (no achievement)
+
+#### `v0/components/animated-counter.tsx`
+
+Reusable number animation. Use `requestAnimationFrame` — no external deps.
+
+```typescript
+'use client'
+import { useEffect, useRef, useState } from 'react'
+
+interface AnimatedCounterProps {
+  from: number
+  to: number
+  duration?: number  // ms, default 1200
+  decimals?: number  // default 1
+  suffix?: string    // e.g. " km"
+}
+
+export function AnimatedCounter({ from, to, duration = 1200, decimals = 1, suffix = '' }: AnimatedCounterProps) {
+  const [value, setValue] = useState(from)
+  const startRef = useRef<number | null>(null)
+  const rafRef = useRef<number>(0)
+
+  useEffect(() => {
+    const animate = (timestamp: number) => {
+      if (startRef.current === null) startRef.current = timestamp
+      const elapsed = timestamp - startRef.current
+      const progress = Math.min(elapsed / duration, 1)
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setValue(from + (to - from) * eased)
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate)
+      }
+    }
+    rafRef.current = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [from, to, duration])
+
+  return <>{value.toFixed(decimals)}{suffix}</>
+}
+```
+
+#### `v0/components/achievement-moment.tsx`
+
+Full-screen overlay. Auto-dismisses after 4500ms OR on any tap. Uses `AhaMomentOverlay` from Phase 1 as the underlying shell.
+
+Copy variants — use Variant C (warm/human) as the shipped default for MVP:
+
+| Scenario | headline | subline |
+|----------|----------|---------|
+| first_run | "You showed up." | "That's not nothing. Most people didn't." |
+| first_run (≥1km) | "Your first run. It had to start somewhere." | "It started today. Everything else builds from here." |
+| personal_best | "You just ran further than you ever have." | "We noticed. That wasn't on anyone's schedule — it just happened." |
+| milestone 5K | "You crossed 5K." | "That distance means something. It always will." |
+| milestone 10K | "You ran 10 kilometres." | "Most people talk about it. You just did it." |
+| milestone 21.1K | "Half marathon distance." | "Every step from here is an encore." |
+
+Show the animated counter only for `personal_best` and `milestone` types (not for `first_run`).
+
+PostHog events:
+- `aha_moment_fired` with `{ moment_id: 'achievement', achievement_type, distance_km, is_first_run }`
+- No explicit CTA — tap anywhere to dismiss, which fires `aha_moment_dismissed`
+
+#### `v0/components/achievement-moment.test.tsx`
+
+At minimum 6 tests:
+- Renders without error for `first_run` context
+- Renders animated counter for `personal_best`
+- `aha_moment_fired` event fires on mount
+- `aha_moment_dismissed` event fires on tap
+- Auto-dismiss via `vi.useFakeTimers()` + `vi.advanceTimersByTime(4500)`
+- No CTA button present (achievement moment has no button)
+
+### Wiring into `record-screen.tsx`
+
+Read `saveRun()` carefully before editing. The injection point is after `recordRunWithSideEffects` returns successfully, before `finalizePostRunFlow`. Add:
+
+```typescript
+// State additions (near isGeneratingPlan state):
+const [achievementContext, setAchievementContext] = useState<AchievementContext | null>(null)
+
+// In saveRun(), after recordRunWithSideEffects() resolves:
+try {
+  const achievement = await detectAchievement(user.id, runId, distance)
+  if (achievement) {
+    setAchievementContext(achievement)
+    return  // AchievementMoment will call finalizePostRunFlow via onDismiss
+  }
+} catch {
+  // Non-critical — fall through to normal post-run flow
+}
+finalizePostRunFlow(runId)
+
+// AchievementMoment render (at end of JSX, before closing tag):
+{achievementContext && savedRunIdRef.current && (
+  <AchievementMoment
+    context={achievementContext}
+    onDismiss={() => {
+      setAchievementContext(null)
+      finalizePostRunFlow(savedRunIdRef.current!)
+    }}
+  />
+)}
+```
+
+Add `savedRunIdRef` to capture the runId for the closure (or pass it through state — follow whatever pattern is already in the file).
+
+---
+
+## DB Persistence Layer (needed by both phases)
+
+### Migration
+
+Create `supabase/migrations/YYYYMMDD_user_aha_moments.sql` (use today's timestamp):
+
+```sql
+CREATE TABLE IF NOT EXISTS user_aha_moments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users NOT NULL,
+  moment_id     TEXT NOT NULL,
+  context       TEXT,
+  variant       TEXT,
+  fired_at      TIMESTAMPTZ DEFAULT NOW(),
+  cta_clicked   BOOLEAN DEFAULT FALSE,
+  dismissed_at  TIMESTAMPTZ,
+  shared        BOOLEAN DEFAULT FALSE,
+  UNIQUE(user_id, moment_id, context)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_aha_moments_user_id ON user_aha_moments(user_id);
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS runner_identity TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS goal_timeline_weeks INTEGER;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS projected_goal_date DATE;
+```
+
+DO NOT apply this migration automatically. Leave a note for the developer to run `supabase db push` or apply via the Supabase dashboard.
+
+### DB helper
+
+Add to `v0/lib/dbUtils.ts`:
+
+```typescript
+export async function recordAhaMoment(params: {
+  userId: string
+  momentId: 'knows_me' | 'achievement' | 'future_vision' | 'noticed'
+  context?: string
+  variant?: string
+}) {
+  const { error } = await supabase
+    .from('user_aha_moments')
+    .upsert(
+      { user_id: params.userId, moment_id: params.momentId, context: params.context, variant: params.variant },
+      { onConflict: 'user_id,moment_id,context', ignoreDuplicates: true }
+    )
+  if (error) console.warn('[recordAhaMoment] failed silently:', error.message)
+}
+
+export async function hasAhaMomentFired(userId: string, momentId: string, context?: string): Promise<boolean> {
+  const query = supabase
+    .from('user_aha_moments')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('moment_id', momentId)
+  if (context) query.eq('context', context)
+  const { data } = await query.limit(1).single()
+  return !!data
+}
+```
+
+---
+
+## Phase 3 — Moment #4 "Someone noticed"
+
+**Read Phase 2 code carefully before starting Phase 3.**
+
+### Context detector
+
+#### `v0/lib/contextDetector.ts`
+
+Pure async function. Receives `run` and `userId`; queries history from Supabase. Returns first matching context in priority order, or `null`.
+
+```typescript
+import { supabase } from '@/lib/supabase'
+import { hasAhaMomentFired } from '@/lib/dbUtils'
+
+export type NoticeContext =
+  | { type: 'streak'; days: 3 | 7 | 14 | 30 | 60 | 100 }
+  | { type: 'comeback'; daysSince: number }
+  | { type: 'high_effort'; percentAbove: number }
+  | { type: 'early_morning'; startedAt: Date }
+  | { type: 'late_night'; startedAt: Date }
+  | { type: 'third_run_week' }
+
+interface RunInput {
+  id: number
+  userId: string
+  distanceKm: number
+  durationSeconds: number
+  startedAt: Date
+  paceMinPerKm?: number
+}
+
+const STREAK_MILESTONES = [3, 7, 14, 30, 60, 100] as const
+
+export async function detectNoticeContext(run: RunInput): Promise<NoticeContext | null> {
+  // 3-day cooldown check
+  const { data: recent } = await supabase
+    .from('user_aha_moments')
+    .select('fired_at')
+    .eq('user_id', run.userId)
+    .eq('moment_id', 'noticed')
+    .order('fired_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (recent?.fired_at) {
+    const daysSinceLast = (Date.now() - new Date(recent.fired_at).getTime()) / 86400000
+    if (daysSinceLast < 3) return null
+  }
+
+  // Streak check (priority 1)
+  const { data: runDates } = await supabase
+    .from('runs')
+    .select('started_at')
+    .eq('user_id', run.userId)
+    .order('started_at', { ascending: false })
+    .limit(110)
+
+  const streak = computeStreak(runDates?.map(r => new Date(r.started_at)) ?? [])
+  for (const milestone of [...STREAK_MILESTONES].reverse()) {
+    if (streak === milestone) {
+      const alreadyFired = await hasAhaMomentFired(run.userId, 'noticed', `streak_${milestone}`)
+      if (!alreadyFired) return { type: 'streak', days: milestone }
+    }
+  }
+
+  // Comeback check (priority 3)
+  const { data: lastRun } = await supabase
+    .from('runs')
+    .select('started_at')
+    .eq('user_id', run.userId)
+    .neq('id', run.id)
+    .order('started_at', { ascending: false })
+    .limit(1)
+    .single()
+
+  if (lastRun?.started_at) {
+    const daysSinceLast = (Date.now() - new Date(lastRun.started_at).getTime()) / 86400000
+    if (daysSinceLast >= 7) return { type: 'comeback', daysSince: Math.round(daysSinceLast) }
+  }
+
+  // High effort check (priority 4)
+  if (run.paceMinPerKm) {
+    const { data: avgData } = await supabase
+      .from('runs')
+      .select('pace_min_per_km')
+      .eq('user_id', run.userId)
+      .neq('id', run.id)
+      .gte('started_at', new Date(Date.now() - 30 * 86400000).toISOString())
+      .not('pace_min_per_km', 'is', null)
+
+    if (avgData && avgData.length >= 3) {
+      const avg = avgData.reduce((sum, r) => sum + r.pace_min_per_km, 0) / avgData.length
+      const improvement = (avg - run.paceMinPerKm) / avg
+      if (improvement >= 0.08) return { type: 'high_effort', percentAbove: Math.round(improvement * 100) }
+    }
+  }
+
+  // Time-of-day checks (priority 5 + 6)
+  const hour = run.startedAt.getHours()
+  const minute = run.startedAt.getMinutes()
+  if (hour < 6 || (hour === 6 && minute === 0)) {
+    return { type: 'early_morning', startedAt: run.startedAt }
+  }
+  if (hour >= 21) {
+    return { type: 'late_night', startedAt: run.startedAt }
+  }
+
+  // Third run in week (priority 10)
+  const weekStart = getWeekStart(run.startedAt)
+  const { count } = await supabase
+    .from('runs')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', run.userId)
+    .gte('started_at', weekStart.toISOString())
+    .neq('id', run.id)
+
+  if ((count ?? 0) >= 2) return { type: 'third_run_week' }
+
+  return null
+}
+
+function computeStreak(runDates: Date[]): number {
+  const days = [...new Set(runDates.map(d => d.toISOString().slice(0, 10)))].sort().reverse()
+  const today = new Date().toISOString().slice(0, 10)
+  let streak = 0
+  let cursor = today
+  for (const day of days) {
+    if (day === cursor) {
+      streak++
+      const prev = new Date(cursor)
+      prev.setDate(prev.getDate() - 1)
+      cursor = prev.toISOString().slice(0, 10)
+    } else if (day < cursor) {
+      break
+    }
+  }
+  return streak
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1))
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+```
+
+#### `v0/lib/contextDetector.test.ts`
+
+Mock `@/lib/supabase` and `@/lib/dbUtils`. Test at minimum:
+- Returns `null` when cooldown < 3 days
+- Returns `{ type: 'streak', days: 7 }` when streak = 7 and not already fired
+- Returns `{ type: 'comeback', daysSince: 10 }` when last run was 10 days ago
+- Returns `{ type: 'high_effort', percentAbove: 12 }` when pace is 12% faster than avg
+- Returns `{ type: 'early_morning' }` for a 5:47am run
+- Returns `null` when no context matches
+
+#### `v0/components/noticed-moment.tsx`
+
+**NOT a full-screen overlay.** An inline card rendered within the run report page between the stats section and the "Next Run" suggestion. No animation — stillness is intentional.
+
+Props:
+```typescript
+interface NoticedMomentProps {
+  context: NoticeContext
+  onShare?: () => void
+}
+```
+
+Copy per context (Variant C — warm/human as default):
+
+| context | headline | subline |
+|---------|----------|---------|
+| streak 3 | "Three days straight." | "The streak has started. This is how habits form." |
+| streak 7 | "Seven days in a row." | "The streak everyone talks about — the one you almost didn't start." |
+| streak 14 | "Two weeks straight." | "You've been at this for two weeks. It's becoming who you are." |
+| streak 30 | "Thirty days." | "A month. Most people don't get here. You did." |
+| comeback | "You're back." | "Gaps aren't failures. Getting back out is what matters." |
+| high_effort | "You pushed today." | `You ran ${percentAbove}% faster than usual. That's not nothing.` |
+| early_morning | `${formattedTime} run.` | "Most of your city is still asleep. You're already done." |
+| late_night | `${formattedTime} run.` | "Whatever was in the way — you went anyway." |
+| third_run_week | "Three runs this week." | "That's the habit. You're building it." |
+
+Visual:
+- `bg-card border-l-4` with accent color (green for streak/achievement, purple for comeback, orange for effort, slate for time-of-day)
+- Icon from lucide-react: `Flame` (streak), `RotateCcw` (comeback), `Zap` (effort), `Sun` (morning), `Moon` (night), `Calendar` (third_run_week)
+- Share icon (`Share2` from lucide-react) at bottom-right if `onShare` is provided
+
+PostHog events:
+- `aha_moment_fired` with `{ moment_id: 'noticed', context: context.type }`
+- `aha_moment_shared` if user taps share
+
+#### `v0/components/noticed-moment.test.tsx`
+
+At minimum 5 tests:
+- Renders correct headline for `streak` context
+- Renders correct headline for `comeback` context
+- `aha_moment_fired` fires on mount with correct context
+- Share button calls `onShare`
+- No share button when `onShare` is undefined
+
+### Wiring Moment #4 into the run report
+
+Find the run report page (likely `v0/app/runs/[id]/report/page.tsx` or `v0/app/activities/[id]/page.tsx`). Read it carefully.
+
+After the run data loads:
+1. Call `detectNoticeContext(run)` — async, non-blocking
+2. If a context is returned, render `<NoticedMoment context={...} />` after the stats section
+3. On successful render, call `recordAhaMoment({ userId, momentId: 'noticed', context: context.type })`
+
+If `detectNoticeContext` throws, silently skip — never block the run report page.
+
+---
+
+## Testing All Phases
+
+After completing all tasks, run:
+
+```bash
+cd /Users/nadavyigal/Documents/RunSmart/v0
+npx vitest run \
+  lib/achievementDetector.test.ts \
+  lib/contextDetector.test.ts \
+  components/achievement-moment.test.tsx \
+  components/noticed-moment.test.tsx
+```
+
+All tests must pass. Then run the full test suite to check for regressions:
+
+```bash
+npx vitest run
+```
+
+---
+
+## Constraints
+
+- No new npm dependencies. `lucide-react` and `@testing-library/react` are already installed.
+- Do not apply the Supabase migration — write the SQL file and add a comment: `-- Run via: supabase db push or Supabase dashboard`
+- Weather API integration is Phase 3 enhanced (post-MVP) — skip it in this implementation
+- All moment components must be error-safe: if detection throws, user never gets blocked
+- Follow the fire-and-forget pattern for analytics: `void trackEvent(...)` before navigation
+
+---
+
+## Commit Convention
+
+One commit per logical unit:
+```
+feat: add achievementDetector with first-run and personal-best detection
+feat: add AnimatedCounter component
+feat: add AchievementMoment component and tests
+feat: wire AchievementMoment into record-screen post-run flow
+feat: add user_aha_moments DB migration and recordAhaMoment helper
+feat: add contextDetector with streak/effort/time-of-day detection
+feat: add NoticedMoment inline card and tests
+feat: wire NoticedMoment into run report page
+```

--- a/tasks/ERRORS.md
+++ b/tasks/ERRORS.md
@@ -1,0 +1,13 @@
+# RunSmart — Failed Approaches Log
+
+Read this before proposing any fix in RunSmart. Never propose an approach already logged here.
+
+## Format
+```
+## YYYY-MM-DD — [Issue description]
+**Tried:** [What was attempted and why it failed]
+**Worked:** [What finally resolved it — fill in when resolved]
+**Next time:** [Key insight to carry forward]
+```
+
+---

--- a/tasks/MEMORY.md
+++ b/tasks/MEMORY.md
@@ -1,0 +1,18 @@
+# RunSmart — Decision Log
+
+Project-specific architectural and product decisions. Read at the start of every RunSmart session.
+
+## Format
+```
+## YYYY-MM-DD — [Decision title]
+**Decided:** [What was chosen]
+**Why:** [The reasoning]
+**Rejected:** [Alternatives considered and why ruled out]
+```
+
+---
+
+## 2026-05-20 — Agentic OS Setup
+**Decided:** Added MEMORY.md, ERRORS.md, hooks, and subagents to Claude Code setup
+**Why:** To eliminate re-explaining context and re-proposing failed approaches between sessions. The "same broken plan next session" loop is now structurally prevented.
+**Rejected:** Minimal patch (MEMORY.md only) — hooks provide enforcement that instructions alone cannot

--- a/v0/app/api/coach/voice-cue/route.ts
+++ b/v0/app/api/coach/voice-cue/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server"
+import { generateText } from "ai"
+import { openai } from "@ai-sdk/openai"
+
+export const runtime = "nodejs"
+export const dynamic = "force-dynamic"
+
+interface VoiceCueRequest {
+  elapsedMinutes: number
+  distanceKm: number
+  currentPaceMinPerKm: number
+  targetPaceMinPerKm?: number
+  workoutGoal?: string
+  heartRateBPM?: number
+}
+
+const COACH_SYSTEM_PROMPT = `You are RunSmart, a calm encouraging running coach.
+Give one short coaching cue (1–2 sentences, max 25 words).
+Be specific to the data provided. Never open with "Great job".
+Never advise running through pain — if the runner mentions pain, say stop and consult a professional.
+Sound like a real coach, not a chatbot.`
+
+export async function POST(request: Request): Promise<Response> {
+  if (process.env.VOICE_COACH_ENABLED !== "true") {
+    return NextResponse.json({ error: "Voice coach is not enabled" }, { status: 503 })
+  }
+
+  let body: VoiceCueRequest
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  const { elapsedMinutes, distanceKm, currentPaceMinPerKm, targetPaceMinPerKm, workoutGoal, heartRateBPM } = body
+
+  const userContext = [
+    `Elapsed: ${elapsedMinutes.toFixed(1)} min`,
+    `Distance: ${distanceKm.toFixed(2)} km`,
+    `Current pace: ${currentPaceMinPerKm.toFixed(1)} min/km`,
+    targetPaceMinPerKm ? `Target pace: ${targetPaceMinPerKm.toFixed(1)} min/km` : null,
+    workoutGoal ? `Goal: ${workoutGoal}` : null,
+    heartRateBPM ? `Heart rate: ${heartRateBPM} bpm` : null,
+  ]
+    .filter(Boolean)
+    .join(", ")
+
+  let cueText: string
+  try {
+    const result = await generateText({
+      model: openai("gpt-4o-mini"),
+      system: COACH_SYSTEM_PROMPT,
+      prompt: userContext,
+      maxTokens: 60,
+    })
+    cueText = result.text.trim()
+  } catch {
+    return NextResponse.json({ error: "Text generation failed" }, { status: 500 })
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: "OpenAI key not configured" }, { status: 500 })
+  }
+
+  let audioBuffer: ArrayBuffer
+  try {
+    const ttsResponse = await fetch("https://api.openai.com/v1/audio/speech", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "tts-1",
+        input: cueText,
+        voice: "nova",
+        response_format: "aac",
+        speed: 0.95,
+      }),
+    })
+    if (!ttsResponse.ok) {
+      return NextResponse.json({ error: "TTS generation failed" }, { status: 500 })
+    }
+    audioBuffer = await ttsResponse.arrayBuffer()
+  } catch {
+    return NextResponse.json({ error: "TTS request failed" }, { status: 500 })
+  }
+
+  return new Response(audioBuffer, {
+    status: 200,
+    headers: {
+      "Content-Type": "audio/aac",
+      "X-Coach-Text": encodeURIComponent(cueText),
+      "Cache-Control": "no-store",
+    },
+  })
+}

--- a/v0/components/achievement-moment.test.tsx
+++ b/v0/components/achievement-moment.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AchievementMoment } from './achievement-moment'
+import { trackOnboardingEvent } from '@/lib/analytics'
+
+vi.mock('@/lib/analytics', () => ({
+  trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('./animated-counter', () => ({
+  AnimatedCounter: ({ to, suffix }: { to: number; suffix?: string }) => (
+    <span data-testid="animated-counter">{to}{suffix}</span>
+  ),
+}))
+
+describe('AchievementMoment', () => {
+  const onDismiss = vi.fn()
+
+  beforeEach(() => {
+    onDismiss.mockClear()
+    vi.mocked(trackOnboardingEvent).mockClear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders without error for first_run context', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'first_run', distanceKm: 0.8 }}
+        onDismiss={onDismiss}
+      />
+    )
+    expect(screen.getByText('You showed up.')).toBeInTheDocument()
+  })
+
+  it('renders animated counter for personal_best', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'personal_best', distanceKm: 6, previousBestKm: 4 }}
+        onDismiss={onDismiss}
+      />
+    )
+    expect(screen.getByTestId('animated-counter')).toBeInTheDocument()
+  })
+
+  it('fires aha_moment_fired on mount', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'first_run', distanceKm: 1.2 }}
+        onDismiss={onDismiss}
+      />
+    )
+    expect(trackOnboardingEvent).toHaveBeenCalledWith(
+      'aha_moment_fired',
+      expect.objectContaining({ moment_id: 'achievement', achievement_type: 'first_run' })
+    )
+  })
+
+  it('fires aha_moment_dismissed on tap', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'first_run', distanceKm: 1.2 }}
+        onDismiss={onDismiss}
+      />
+    )
+    fireEvent.click(screen.getByTestId('achievement-moment'))
+    expect(trackOnboardingEvent).toHaveBeenCalledWith(
+      'aha_moment_dismissed',
+      expect.objectContaining({ moment_id: 'achievement' })
+    )
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('auto-dismisses after 4500ms', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'first_run', distanceKm: 1.2 }}
+        onDismiss={onDismiss}
+      />
+    )
+    vi.advanceTimersByTime(4500)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render a CTA button', () => {
+    render(
+      <AchievementMoment
+        context={{ type: 'milestone', distanceKm: 5.2, milestoneKm: 5 }}
+        onDismiss={onDismiss}
+      />
+    )
+    expect(screen.queryByTestId('aha-moment-cta')).not.toBeInTheDocument()
+  })
+})

--- a/v0/components/achievement-moment.tsx
+++ b/v0/components/achievement-moment.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { trackOnboardingEvent } from '@/lib/analytics'
+import { AnimatedCounter } from './animated-counter'
+import type { AchievementContext } from '@/lib/achievementDetector'
+
+interface AchievementMomentProps {
+  context: AchievementContext
+  onDismiss: () => void
+}
+
+const AUTO_DISMISS_MS = 4500
+
+function getCopy(context: AchievementContext): { headline: string; subline: string } {
+  switch (context.type) {
+    case 'first_run':
+      if (context.distanceKm >= 1) {
+        return {
+          headline: 'Your first run. It had to start somewhere.',
+          subline: 'It started today. Everything else builds from here.',
+        }
+      }
+      return {
+        headline: 'You showed up.',
+        subline: "That's not nothing. Most people didn't.",
+      }
+    case 'personal_best':
+      return {
+        headline: 'You just ran further than you ever have.',
+        subline: "We noticed. That wasn't on anyone's schedule — it just happened.",
+      }
+    case 'milestone':
+      if (context.milestoneKm === 5) {
+        return { headline: 'You crossed 5K.', subline: 'That distance means something. It always will.' }
+      }
+      if (context.milestoneKm === 10) {
+        return {
+          headline: 'You ran 10 kilometres.',
+          subline: 'Most people talk about it. You just did it.',
+        }
+      }
+      return {
+        headline: 'Half marathon distance.',
+        subline: 'Every step from here is an encore.',
+      }
+    default:
+      return { headline: 'Nice work.', subline: 'Keep going.' }
+  }
+}
+
+export function AchievementMoment({ context, onDismiss }: AchievementMomentProps) {
+  const [visible, setVisible] = useState(false)
+  const { headline, subline } = getCopy(context)
+
+  const handleDismiss = useCallback(() => {
+    void trackOnboardingEvent('aha_moment_dismissed', {
+      moment_id: 'achievement',
+      achievement_type: context.type,
+      distance_km: context.distanceKm,
+      is_first_run: context.type === 'first_run',
+    })
+    onDismiss()
+  }, [context, onDismiss])
+
+  useEffect(() => {
+    void trackOnboardingEvent('aha_moment_fired', {
+      moment_id: 'achievement',
+      achievement_type: context.type,
+      distance_km: context.distanceKm,
+      is_first_run: context.type === 'first_run',
+    })
+  }, [context])
+
+  useEffect(() => {
+    const frameId = requestAnimationFrame(() => setVisible(true))
+    const timerId = window.setTimeout(handleDismiss, AUTO_DISMISS_MS)
+    return () => {
+      cancelAnimationFrame(frameId)
+      window.clearTimeout(timerId)
+    }
+  }, [handleDismiss])
+
+  const showCounter = context.type === 'personal_best' || context.type === 'milestone'
+
+  return (
+    <div
+      data-testid="achievement-moment"
+      role="button"
+      tabIndex={0}
+      onClick={handleDismiss}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault()
+          handleDismiss()
+        }
+      }}
+      className={cn(
+        'fixed inset-0 z-[60] flex flex-col items-center justify-center',
+        'bg-[oklch(12%_0.02_255)] text-white px-8 cursor-pointer',
+        'transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      {showCounter && (
+        <div
+          className={cn(
+            'mb-8 text-5xl font-bold tabular-nums transition-all duration-300 delay-100',
+            visible ? 'opacity-100 scale-100' : 'opacity-0 scale-90'
+          )}
+        >
+          {context.type === 'personal_best' ? (
+            <AnimatedCounter
+              from={context.previousBestKm}
+              to={context.distanceKm}
+              suffix=" km"
+            />
+          ) : (
+            <AnimatedCounter from={0} to={context.milestoneKm} suffix=" km" />
+          )}
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'text-center space-y-3 max-w-sm transition-all duration-300 delay-200',
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+        )}
+      >
+        <h2 className="text-2xl font-semibold leading-snug">{headline}</h2>
+        <p className="text-white/60 text-sm leading-relaxed">{subline}</p>
+      </div>
+    </div>
+  )
+}

--- a/v0/components/aha-moment-overlay.tsx
+++ b/v0/components/aha-moment-overlay.tsx
@@ -1,0 +1,94 @@
+// v0/components/aha-moment-overlay.tsx
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+
+interface AhaMomentOverlayProps {
+  headline: string
+  subline: string
+  ctaLabel: string
+  onCTA: () => void
+  onSkip: () => void
+  skipLabel?: string
+  children?: React.ReactNode // slot for the visual above headline
+}
+
+export function AhaMomentOverlay({
+  headline,
+  subline,
+  ctaLabel,
+  onCTA,
+  onSkip,
+  skipLabel = 'Skip for now',
+  children,
+}: AhaMomentOverlayProps) {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // Defer to next frame so CSS transition fires
+    const id = requestAnimationFrame(() => setVisible(true))
+    return () => cancelAnimationFrame(id)
+  }, [])
+
+  return (
+    <div
+      data-testid="aha-moment-overlay"
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col items-center justify-center',
+        'bg-[oklch(12%_0.02_255)] text-white px-8',
+        'transition-opacity duration-300',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      {/* Visual slot */}
+      {children && (
+        <div
+          className={cn(
+            'mb-8 transition-all duration-300 delay-100',
+            visible ? 'opacity-100 scale-100' : 'opacity-0 scale-90'
+          )}
+        >
+          {children}
+        </div>
+      )}
+
+      {/* Text */}
+      <div
+        className={cn(
+          'text-center space-y-3 max-w-sm transition-all duration-300 delay-200',
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+        )}
+      >
+        <h2 className="text-2xl font-semibold leading-snug">{headline}</h2>
+        <p className="text-white/60 text-sm leading-relaxed">{subline}</p>
+      </div>
+
+      {/* Actions */}
+      <div
+        className={cn(
+          'mt-10 w-full max-w-sm flex flex-col gap-3 transition-all duration-300 delay-300',
+          visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+        )}
+      >
+        <Button
+          type="button"
+          data-testid="aha-moment-cta"
+          className="w-full h-14 text-lg font-bold rounded-2xl bg-white text-neutral-950 hover:bg-white/95"
+          onClick={onCTA}
+        >
+          {ctaLabel}
+        </Button>
+        <button
+          type="button"
+          data-testid="aha-moment-skip"
+          className="w-full py-2 text-sm text-white/40 hover:text-white/60 transition-colors"
+          onClick={onSkip}
+        >
+          {skipLabel}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/v0/components/animated-counter.tsx
+++ b/v0/components/animated-counter.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+interface AnimatedCounterProps {
+  from: number
+  to: number
+  duration?: number
+  decimals?: number
+  suffix?: string
+}
+
+export function AnimatedCounter({
+  from,
+  to,
+  duration = 1200,
+  decimals = 1,
+  suffix = '',
+}: AnimatedCounterProps) {
+  const [value, setValue] = useState(from)
+  const startRef = useRef<number | null>(null)
+  const rafRef = useRef<number>(0)
+
+  useEffect(() => {
+    startRef.current = null
+    setValue(from)
+
+    const animate = (timestamp: number) => {
+      if (startRef.current === null) startRef.current = timestamp
+      const elapsed = timestamp - startRef.current
+      const progress = Math.min(elapsed / duration, 1)
+      const eased = 1 - Math.pow(1 - progress, 3)
+      setValue(from + (to - from) * eased)
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(animate)
+      }
+    }
+
+    rafRef.current = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(rafRef.current)
+  }, [from, to, duration])
+
+  return (
+    <>
+      {value.toFixed(decimals)}
+      {suffix}
+    </>
+  )
+}

--- a/v0/components/goal-timeline-moment.test.tsx
+++ b/v0/components/goal-timeline-moment.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GoalTimelineMoment } from './goal-timeline-moment'
+
+vi.mock('@/lib/analytics', () => ({
+  trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('./aha-moment-overlay', () => ({
+  AhaMomentOverlay: ({ headline, subline, ctaLabel, onCTA, onSkip, children }: {
+    headline: string
+    subline: string
+    ctaLabel: string
+    onCTA: () => void
+    onSkip: () => void
+    children?: React.ReactNode
+  }) => (
+    <div data-testid="aha-moment-overlay">
+      <div>{headline}</div>
+      <div>{subline}</div>
+      {children}
+      <button data-testid="aha-moment-cta" onClick={onCTA}>{ctaLabel}</button>
+      <button data-testid="aha-moment-skip" onClick={onSkip}>Skip</button>
+    </div>
+  ),
+}))
+
+const mockTimeline = {
+  weeks: 8,
+  milestoneWeek: 4,
+  milestoneLabel: 'Halfway there',
+  goalLabel: 'New distance goal',
+  projectedDate: new Date('2026-08-05'),
+}
+
+describe('GoalTimelineMoment', () => {
+  const onCTA = vi.fn()
+  const onSkip = vi.fn()
+
+  beforeEach(() => {
+    onCTA.mockClear()
+    onSkip.mockClear()
+  })
+
+  it('renders the timeline graphic', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByTestId('timeline-graphic')).toBeInTheDocument()
+  })
+
+  it('renders the correct headline for distance goal', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText(/8 weeks away/i)).toBeInTheDocument()
+  })
+
+  it('renders the correct headline for habit goal', () => {
+    render(<GoalTimelineMoment goal="habit" timeline={{ ...mockTimeline, weeks: 4 }} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText(/feel like a habit/i)).toBeInTheDocument()
+  })
+
+  it('renders the correct headline for speed goal', () => {
+    render(<GoalTimelineMoment goal="speed" timeline={{ ...mockTimeline, weeks: 6 }} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText(/running faster/i)).toBeInTheDocument()
+  })
+
+  it('shows milestone label in timeline', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText('Halfway there')).toBeInTheDocument()
+  })
+
+  it('calls onCTA when CTA is clicked', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('aha-moment-cta'))
+    expect(onCTA).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSkip when skip is clicked', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('aha-moment-skip'))
+    expect(onSkip).toHaveBeenCalledTimes(1)
+  })
+
+  it('CTA button label is "Show me the plan"', () => {
+    render(<GoalTimelineMoment goal="distance" timeline={mockTimeline} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByTestId('aha-moment-cta')).toHaveTextContent('Show me the plan')
+  })
+})

--- a/v0/components/goal-timeline-moment.test.tsx
+++ b/v0/components/goal-timeline-moment.test.tsx
@@ -1,6 +1,8 @@
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { GoalTimelineMoment } from './goal-timeline-moment'
+import { trackOnboardingEvent } from '@/lib/analytics'
 
 vi.mock('@/lib/analytics', () => ({
   trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
@@ -42,6 +44,7 @@ describe('GoalTimelineMoment', () => {
   const onSkip = vi.fn()
 
   beforeEach(() => {
+    vi.mocked(trackOnboardingEvent).mockClear()
     onCTA.mockClear()
     onSkip.mockClear()
   })

--- a/v0/components/goal-timeline-moment.tsx
+++ b/v0/components/goal-timeline-moment.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { cn } from '@/lib/utils'
 import { trackOnboardingEvent } from '@/lib/analytics'
 import { AhaMomentOverlay } from './aha-moment-overlay'
 import type { GoalTimeline } from '@/lib/userInsightService'

--- a/v0/components/goal-timeline-moment.tsx
+++ b/v0/components/goal-timeline-moment.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { trackOnboardingEvent } from '@/lib/analytics'
+import { AhaMomentOverlay } from './aha-moment-overlay'
+import type { GoalTimeline } from '@/lib/userInsightService'
+
+interface GoalTimelineMomentProps {
+  goal: string
+  timeline: GoalTimeline
+  onCTA: () => void
+  onSkip: () => void
+}
+
+function formatProjectedDate(date: Date): string {
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+function buildHeadline(goal: string, timeline: GoalTimeline): string {
+  switch (goal) {
+    case 'distance':
+      return `Your ${timeline.goalLabel} is ${timeline.weeks} weeks away.`
+    case 'speed':
+      return `In ${timeline.weeks} weeks, you'll be running faster than today.`
+    case 'habit':
+    default:
+      return `In ${timeline.weeks} weeks, running will feel like a habit.`
+  }
+}
+
+function buildSubline(goal: string, timeline: GoalTimeline): string {
+  const dateStr = formatProjectedDate(timeline.projectedDate)
+  switch (goal) {
+    case 'distance':
+      return `Follow your plan 3 days a week. By ${dateStr}, you'll be there.`
+    case 'speed':
+      return `We'll sharpen your pace week by week. By ${dateStr}, you'll feel it.`
+    case 'habit':
+    default:
+      return `Three runs a week is all it takes. By ${dateStr}, it'll be automatic.`
+  }
+}
+
+function TimelineGraphic({
+  milestoneWeek,
+  milestoneLabel,
+  goalLabel,
+  weeks,
+}: Pick<GoalTimeline, 'milestoneWeek' | 'milestoneLabel' | 'goalLabel' | 'weeks'>) {
+  const [animated, setAnimated] = useState(false)
+
+  useEffect(() => {
+    const id = setTimeout(() => setAnimated(true), 400)
+    return () => clearTimeout(id)
+  }, [])
+
+  return (
+    <div data-testid="timeline-graphic" className="w-full max-w-xs mx-auto">
+      <div className="relative flex items-start justify-between pt-2">
+        {/* Background line */}
+        <div className="absolute top-5 left-4 right-4 h-0.5 bg-white/10" />
+        {/* Animated progress line */}
+        <div
+          className="absolute top-5 left-4 h-0.5 bg-primary transition-all duration-700 ease-out"
+          style={{ right: animated ? '1rem' : '100%' }}
+        />
+
+        {/* Today dot */}
+        <div className="relative z-10 flex flex-col items-center gap-2 w-14">
+          <div className="w-4 h-4 rounded-full bg-white/50 border-2 border-white/70 mt-1" />
+          <span className="text-[10px] text-white/50 text-center leading-tight">Today</span>
+        </div>
+
+        {/* Milestone dot */}
+        <div className="relative z-10 flex flex-col items-center gap-2 w-20">
+          <div className="w-3 h-3 rounded-full bg-white/15 border border-white/30 mt-1.5" />
+          <span className="text-[10px] text-white/40 text-center leading-tight">{milestoneLabel}</span>
+          <span className="text-[10px] text-white/25 text-center">Wk {milestoneWeek}</span>
+        </div>
+
+        {/* Goal dot */}
+        <div className="relative z-10 flex flex-col items-center gap-2 w-14">
+          <div className="w-5 h-5 rounded-full bg-primary shadow-lg shadow-primary/30 mt-0.5" />
+          <span className="text-[10px] text-primary font-medium text-center leading-tight">{goalLabel}</span>
+          <span className="text-[10px] text-white/30 text-center">Wk {weeks}</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function GoalTimelineMoment({ goal, timeline, onCTA, onSkip }: GoalTimelineMomentProps) {
+  const headline = buildHeadline(goal, timeline)
+  const subline = buildSubline(goal, timeline)
+
+  useEffect(() => {
+    void trackOnboardingEvent('aha_moment_fired', {
+      moment_id: 'future_vision',
+      variant: 'C',
+      goal,
+      weeks_to_goal: timeline.weeks,
+    })
+  }, [goal, timeline.weeks])
+
+  const handleCTA = () => {
+    void trackOnboardingEvent('aha_moment_cta_clicked', {
+      moment_id: 'future_vision',
+      variant: 'C',
+      goal,
+    })
+    onCTA()
+  }
+
+  const handleSkip = () => {
+    void trackOnboardingEvent('aha_moment_dismissed', {
+      moment_id: 'future_vision',
+      variant: 'C',
+      goal,
+    })
+    onSkip()
+  }
+
+  return (
+    <AhaMomentOverlay
+      headline={headline}
+      subline={subline}
+      ctaLabel="Show me the plan"
+      onCTA={handleCTA}
+      onSkip={handleSkip}
+    >
+      <TimelineGraphic
+        milestoneWeek={timeline.milestoneWeek}
+        milestoneLabel={timeline.milestoneLabel}
+        goalLabel={timeline.goalLabel}
+        weeks={timeline.weeks}
+      />
+    </AhaMomentOverlay>
+  )
+}

--- a/v0/components/noticed-moment.test.tsx
+++ b/v0/components/noticed-moment.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NoticedMoment } from './noticed-moment'
+import { trackOnboardingEvent } from '@/lib/analytics'
+
+vi.mock('@/lib/analytics', () => ({
+  trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+describe('NoticedMoment', () => {
+  beforeEach(() => {
+    vi.mocked(trackOnboardingEvent).mockClear()
+  })
+
+  it('renders correct headline for streak context', () => {
+    render(<NoticedMoment context={{ type: 'streak', days: 7 }} />)
+    expect(screen.getByText('Seven days in a row.')).toBeInTheDocument()
+  })
+
+  it('renders correct headline for comeback context', () => {
+    render(<NoticedMoment context={{ type: 'comeback', daysSince: 12 }} />)
+    expect(screen.getByText("You're back.")).toBeInTheDocument()
+  })
+
+  it('fires aha_moment_fired on mount with correct context', () => {
+    render(<NoticedMoment context={{ type: 'third_run_week' }} />)
+    expect(trackOnboardingEvent).toHaveBeenCalledWith('aha_moment_fired', {
+      moment_id: 'noticed',
+      context: 'third_run_week',
+    })
+  })
+
+  it('share button calls onShare', () => {
+    const onShare = vi.fn()
+    render(<NoticedMoment context={{ type: 'streak', days: 3 }} onShare={onShare} />)
+    fireEvent.click(screen.getByTestId('noticed-moment-share'))
+    expect(onShare).toHaveBeenCalledTimes(1)
+    expect(trackOnboardingEvent).toHaveBeenCalledWith(
+      'aha_moment_shared',
+      expect.objectContaining({ moment_id: 'noticed', context: 'streak' })
+    )
+  })
+
+  it('does not render share button when onShare is undefined', () => {
+    render(<NoticedMoment context={{ type: 'streak', days: 3 }} />)
+    expect(screen.queryByTestId('noticed-moment-share')).not.toBeInTheDocument()
+  })
+})

--- a/v0/components/noticed-moment.tsx
+++ b/v0/components/noticed-moment.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect } from 'react'
+import {
+  Calendar,
+  Flame,
+  Moon,
+  RotateCcw,
+  Share2,
+  Sun,
+  Zap,
+  type LucideIcon,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { trackOnboardingEvent } from '@/lib/analytics'
+import type { NoticeContext } from '@/lib/contextDetector'
+
+interface NoticedMomentProps {
+  context: NoticeContext
+  onShare?: () => void
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  })
+}
+
+function getCopy(context: NoticeContext): { headline: string; subline: string } {
+  switch (context.type) {
+    case 'streak':
+      if (context.days === 3) {
+        return {
+          headline: 'Three days straight.',
+          subline: 'The streak has started. This is how habits form.',
+        }
+      }
+      if (context.days === 7) {
+        return {
+          headline: 'Seven days in a row.',
+          subline: "The streak everyone talks about — the one you almost didn't start.",
+        }
+      }
+      if (context.days === 14) {
+        return {
+          headline: 'Two weeks straight.',
+          subline: "You've been at this for two weeks. It's becoming who you are.",
+        }
+      }
+      if (context.days === 30) {
+        return {
+          headline: 'Thirty days.',
+          subline: "A month. Most people don't get here. You did.",
+        }
+      }
+      return {
+        headline: `${context.days} days in a row.`,
+        subline: 'Consistency like this is rare. Keep showing up.',
+      }
+    case 'comeback':
+      return {
+        headline: "You're back.",
+        subline: "Gaps aren't failures. Getting back out is what matters.",
+      }
+    case 'high_effort':
+      return {
+        headline: 'You pushed today.',
+        subline: `You ran ${context.percentAbove}% faster than usual. That's not nothing.`,
+      }
+    case 'early_morning':
+      return {
+        headline: `${formatTime(context.startedAt)} run.`,
+        subline: "Most of your city is still asleep. You're already done.",
+      }
+    case 'late_night':
+      return {
+        headline: `${formatTime(context.startedAt)} run.`,
+        subline: 'Whatever was in the way — you went anyway.',
+      }
+    case 'third_run_week':
+      return {
+        headline: 'Three runs this week.',
+        subline: "That's the habit. You're building it.",
+      }
+    default:
+      return { headline: 'Nice work.', subline: 'We noticed.' }
+  }
+}
+
+function getVisual(context: NoticeContext): { Icon: LucideIcon; accentClass: string } {
+  switch (context.type) {
+    case 'streak':
+      return { Icon: Flame, accentClass: 'border-emerald-500 text-emerald-600' }
+    case 'comeback':
+      return { Icon: RotateCcw, accentClass: 'border-violet-500 text-violet-600' }
+    case 'high_effort':
+      return { Icon: Zap, accentClass: 'border-orange-500 text-orange-600' }
+    case 'early_morning':
+      return { Icon: Sun, accentClass: 'border-slate-500 text-slate-600' }
+    case 'late_night':
+      return { Icon: Moon, accentClass: 'border-slate-500 text-slate-600' }
+    case 'third_run_week':
+      return { Icon: Calendar, accentClass: 'border-emerald-500 text-emerald-600' }
+    default:
+      return { Icon: Flame, accentClass: 'border-emerald-500 text-emerald-600' }
+  }
+}
+
+export function NoticedMoment({ context, onShare }: NoticedMomentProps) {
+  const { headline, subline } = getCopy(context)
+  const { Icon, accentClass } = getVisual(context)
+
+  useEffect(() => {
+    void trackOnboardingEvent('aha_moment_fired', {
+      moment_id: 'noticed',
+      context: context.type,
+    })
+  }, [context.type])
+
+  const handleShare = () => {
+    void trackOnboardingEvent('aha_moment_shared', {
+      moment_id: 'noticed',
+      context: context.type,
+    })
+    onShare?.()
+  }
+
+  return (
+    <div
+      data-testid="noticed-moment"
+      className={cn('bg-card border-l-4 rounded-lg p-4 mx-4 relative', accentClass.split(' ')[0])}
+    >
+      <div className="flex items-start gap-3 pr-8">
+        <Icon className={cn('h-5 w-5 mt-0.5 shrink-0', accentClass.split(' ')[1])} aria-hidden="true" />
+        <div className="space-y-1">
+          <h3 className="font-semibold text-foreground leading-snug">{headline}</h3>
+          <p className="text-sm text-muted-foreground leading-relaxed">{subline}</p>
+        </div>
+      </div>
+      {onShare && (
+        <button
+          type="button"
+          data-testid="noticed-moment-share"
+          onClick={handleShare}
+          className="absolute bottom-3 right-3 p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          aria-label="Share"
+        >
+          <Share2 className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/v0/components/onboarding-screen.tsx
+++ b/v0/components/onboarding-screen.tsx
@@ -33,6 +33,14 @@ import { UserPrivacySettings } from "@/components/privacy-dashboard"
 import { cn } from "@/lib/utils"
 import { getChallengeTemplateBySlug, type ChallengeTemplateSeed } from "@/lib/challengeTemplates"
 import { syncPlanWithChallenge } from "@/lib/challenge-plan-sync"
+import {
+  getRunningIdentity,
+  projectGoalTimeline,
+  type RunnerIdentity,
+  type GoalTimeline,
+} from '@/lib/userInsightService'
+import { RunnerIdentityMoment } from '@/components/runner-identity-moment'
+import { GoalTimelineMoment } from '@/components/goal-timeline-moment'
 
 type Weekday = 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun'
 
@@ -425,6 +433,12 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
     push: false,
   })
   const [isGeneratingPlan, setIsGeneratingPlan] = useState(false)
+  type AhaMomentStage = 'identity' | 'timeline' | null
+  const [ahaMomentStage, setAhaMomentStage] = useState<AhaMomentStage>(null)
+  const [ahaMomentData, setAhaMomentData] = useState<{
+    identity: RunnerIdentity
+    timeline: GoalTimeline
+  } | null>(null)
   const [privacyAccepted, setPrivacyAccepted] = useState(false)
   const [privacySettings] = useState<UserPrivacySettings>({
     dataCollection: {
@@ -883,14 +897,23 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
           description: "Your personalized running journey begins now!",
         })
 
-        // Call the parent's onComplete callback to trigger navigation
+        // Show aha moments before navigating
         try {
-          onComplete()
-          console.log('✅ [OnboardingScreen] onComplete() called successfully')
-        } catch (error) {
-          console.error('❌ [OnboardingScreen] Error calling onComplete():', error)
-          // Force navigation even if callback fails
-          setIsGeneratingPlan(false)
+          const paceMinPerKm = referenceRaceTimeSeconds > 0 && referenceRaceDistance > 0
+            ? (referenceRaceTimeSeconds / 60) / referenceRaceDistance
+            : 7.0
+          const identity = getRunningIdentity(selectedGoal, selectedExperience, paceMinPerKm)
+          const timeline = projectGoalTimeline(selectedGoal, selectedExperience)
+          setAhaMomentData({ identity, timeline })
+          setAhaMomentStage('identity')
+          console.log('✅ [OnboardingScreen] Aha moments queued')
+        } catch (momentError) {
+          console.error('❌ [OnboardingScreen] Aha moment setup failed, skipping to app:', momentError)
+          try {
+            onComplete()
+          } catch {
+            setIsGeneratingPlan(false)
+          }
         }
 
       } else {
@@ -1367,6 +1390,30 @@ export function OnboardingScreen({ onComplete }: OnboardingScreenProps) {
           </Button>
         </div>
       </div>
+      {ahaMomentStage === 'identity' && ahaMomentData && (
+        <RunnerIdentityMoment
+          identity={ahaMomentData.identity}
+          onCTA={() => setAhaMomentStage('timeline')}
+          onSkip={() => {
+            setAhaMomentStage(null)
+            onComplete()
+          }}
+        />
+      )}
+      {ahaMomentStage === 'timeline' && ahaMomentData && (
+        <GoalTimelineMoment
+          goal={selectedGoal}
+          timeline={ahaMomentData.timeline}
+          onCTA={() => {
+            setAhaMomentStage(null)
+            onComplete()
+          }}
+          onSkip={() => {
+            setAhaMomentStage(null)
+            onComplete()
+          }}
+        />
+      )}
     </OnboardingErrorBoundary>
   )
 }

--- a/v0/components/record-screen.tsx
+++ b/v0/components/record-screen.tsx
@@ -21,6 +21,8 @@ import { getActiveChallenge, updateChallengeOnWorkoutComplete } from "@/lib/chal
 import { startChallengeAndSyncPlan } from "@/lib/challenge-plan-sync"
 import { ENABLE_AUTO_PAUSE, ENABLE_VIBRATION_COACH, ENABLE_AUDIO_COACH } from "@/lib/featureFlags"
 import { recordRunWithSideEffects, retryPostRunAdaptation } from "@/lib/run-recording"
+import { detectAchievement, type AchievementContext } from "@/lib/achievementDetector"
+import { AchievementMoment } from "@/components/achievement-moment"
 import {
   getCoachingCueState,
   initializeCoachingCues,
@@ -370,6 +372,8 @@ export function RecordScreen() {
   const [challengeCompletionData, setChallengeCompletionData] = useState<{ progress: ChallengeProgress; template: ChallengeTemplate } | null>(null)
   const [pendingRpeRunId, setPendingRpeRunId] = useState<number | null>(null)
   const [showPostRunRpeModal, setShowPostRunRpeModal] = useState(false)
+  const [achievementContext, setAchievementContext] = useState<AchievementContext | null>(null)
+  const savedRunIdRef = useRef<number | null>(null)
   const [activeChallenge, setActiveChallenge] = useState<{ progress: ChallengeProgress; template: ChallengeTemplate } | null>(null)
   const [currentWorkout, setCurrentWorkout] = useState<Workout | null>(null)
   const [currentUser, setCurrentUser] = useState<User | null>(null)
@@ -539,9 +543,9 @@ export function RecordScreen() {
 
   useEffect(() => {
     if (!pendingRpeRunId) return
-    if (completionModalData || challengeCompletionData) return
+    if (completionModalData || challengeCompletionData || achievementContext) return
     setShowPostRunRpeModal(true)
-  }, [pendingRpeRunId, completionModalData, challengeCompletionData])
+  }, [pendingRpeRunId, completionModalData, challengeCompletionData, achievementContext])
 
   const logGps = (payload: Record<string, unknown>) => {
     if (!gpsDebugEnabled) return
@@ -2526,6 +2530,16 @@ export function RecordScreen() {
         }
       }
 
+      savedRunIdRef.current = runId
+      try {
+        const achievement = await detectAchievement(user.id, runId, distance)
+        if (achievement) {
+          setAchievementContext(achievement)
+        }
+      } catch {
+        // Non-critical — fall through to normal post-run flow
+      }
+
       setPendingRpeRunId(runId)
     } catch (error) {
       console.error('Error saving run:', error)
@@ -3604,6 +3618,14 @@ export function RecordScreen() {
           }}
           initialStep="upload"
           {...(currentWorkout?.id ? { workoutId: currentWorkout.id } : {})}
+        />
+      )}
+      {achievementContext && savedRunIdRef.current && (
+        <AchievementMoment
+          context={achievementContext}
+          onDismiss={() => {
+            setAchievementContext(null)
+          }}
         />
       )}
       {pendingRpeRunId !== null && (

--- a/v0/components/run-report-screen.tsx
+++ b/v0/components/run-report-screen.tsx
@@ -31,6 +31,9 @@ import { RecoveryTimeline, type DetailedRecovery } from './run-report/RecoveryTi
 import { RouteTimeline } from './run-report/RouteTimeline'
 import { RunReportHeader } from './run-report/RunReportHeader'
 import { ShareRunCTA } from './run-report/ShareRunCTA'
+import { detectNoticeContext, type NoticeContext } from '@/lib/contextDetector'
+import { recordAhaMoment } from '@/lib/dbUtils'
+import { NoticedMoment } from './noticed-moment'
 import { SplitsTable } from './run-report/SplitsTable'
 import { StructuredWorkoutCard, type StructuredWorkout } from './run-report/StructuredWorkoutCard'
 
@@ -368,6 +371,7 @@ export function RunReportScreen({ runId, onBack }: { runId: number | null; onBac
   const [garminTelemetry, setGarminTelemetry] = useState<GarminTelemetry | null>(null)
   const [garminTelemetryResolved, setGarminTelemetryResolved] = useState(false)
   const [historicalContext, setHistoricalContext] = useState<Record<string, unknown> | null>(null)
+  const [noticeContext, setNoticeContext] = useState<NoticeContext | null>(null)
   const autoRegeneratedRunRef = useRef<number | null>(null)
 
   const gpsQualityEnabled = ENABLE_AUTO_PAUSE
@@ -562,6 +566,43 @@ export function RunReportScreen({ runId, onBack }: { runId: number | null; onBac
   useEffect(() => {
     loadRun()
   }, [loadRun])
+
+  useEffect(() => {
+    if (!run?.id) {
+      setNoticeContext(null)
+      return
+    }
+
+    const detect = async () => {
+      try {
+        const paceMinPerKm =
+          run.distance >= MIN_DISTANCE_FOR_PACE_KM ? run.duration / 60 / run.distance : undefined
+        const context = await detectNoticeContext({
+          id: run.id!,
+          userId: run.userId,
+          distanceKm: run.distance,
+          durationSeconds: run.duration,
+          startedAt: new Date(run.completedAt),
+          paceMinPerKm,
+        })
+
+        if (!context) return
+
+        setNoticeContext(context)
+        const contextKey =
+          context.type === 'streak' ? `streak_${context.days}` : context.type
+        void recordAhaMoment({
+          userId: run.userId,
+          momentId: 'noticed',
+          context: contextKey,
+        })
+      } catch {
+        // Non-critical — never block the run report page
+      }
+    }
+
+    void detect()
+  }, [run])
 
   // Gather historical context from Dexie for richer AI analysis
   useEffect(() => {
@@ -977,6 +1018,9 @@ export function RunReportScreen({ runId, onBack }: { runId: number | null; onBac
       coachScore && (
         <CoachScoreRing key="coach-score" score={coachScore} variant="garmin" />
       ),
+      noticeContext && (
+        <NoticedMoment key="noticed" context={noticeContext} onShare={onShare} />
+      ),
       <EffortAnalysis
         key="effort"
         avgHr={(garminTelemetry?.avgHr ?? run.heartRate) as any}
@@ -1111,6 +1155,9 @@ export function RunReportScreen({ runId, onBack }: { runId: number | null; onBac
     />,
     coachScore && (
       <CoachScoreRing key="coach-score" score={coachScore} variant="light" />
+    ),
+    noticeContext && (
+      <NoticedMoment key="noticed" context={noticeContext} onShare={onShare} />
     ),
     (runEffort || pacingInsight?.paceConsistency || (garminTelemetry?.avgHr ?? run.heartRate)) && (
       <EffortAnalysis

--- a/v0/components/runner-identity-moment.test.tsx
+++ b/v0/components/runner-identity-moment.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RunnerIdentityMoment } from './runner-identity-moment'
+import { trackOnboardingEvent } from '@/lib/analytics'
 
 vi.mock('@/lib/analytics', () => ({
   trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
@@ -47,6 +48,7 @@ describe('RunnerIdentityMoment', () => {
   beforeEach(() => {
     onCTA.mockClear()
     onSkip.mockClear()
+    vi.mocked(trackOnboardingEvent).mockClear()
   })
 
   it('renders the identity label', () => {

--- a/v0/components/runner-identity-moment.test.tsx
+++ b/v0/components/runner-identity-moment.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RunnerIdentityMoment } from './runner-identity-moment'
+
+vi.mock('@/lib/analytics', () => ({
+  trackOnboardingEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}))
+
+vi.mock('./aha-moment-overlay', () => ({
+  AhaMomentOverlay: ({ headline, subline, ctaLabel, onCTA, onSkip, children }: {
+    headline: string
+    subline: string
+    ctaLabel: string
+    onCTA: () => void
+    onSkip: () => void
+    children?: React.ReactNode
+  }) => (
+    <div data-testid="aha-moment-overlay">
+      <div>{headline}</div>
+      <div>{subline}</div>
+      {children}
+      <button data-testid="aha-moment-cta" onClick={onCTA}>{ctaLabel}</button>
+      <button data-testid="aha-moment-skip" onClick={onSkip}>Skip</button>
+    </div>
+  ),
+}))
+
+const mockIdentity = {
+  id: 'endurance_builder' as const,
+  label: 'Endurance Builder',
+  glyph: '⛰️',
+  accentColor: 'text-emerald-400',
+  ringColor: 'ring-emerald-400/40',
+  headline: "We can already tell — you're in it for the miles, not the medals.",
+  subline: "That's the kind of runner who surprises themselves. Let's find out how far.",
+  ctaLabel: "I'm ready",
+}
+
+describe('RunnerIdentityMoment', () => {
+  const onCTA = vi.fn()
+  const onSkip = vi.fn()
+
+  beforeEach(() => {
+    onCTA.mockClear()
+    onSkip.mockClear()
+  })
+
+  it('renders the identity label', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText('Endurance Builder')).toBeInTheDocument()
+  })
+
+  it('renders the identity glyph', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByTestId('identity-glyph')).toBeInTheDocument()
+  })
+
+  it('renders the headline', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByText(/in it for the miles/i)).toBeInTheDocument()
+  })
+
+  it('calls onCTA when CTA button is clicked', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('aha-moment-cta'))
+    expect(onCTA).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onSkip when skip button is clicked', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    fireEvent.click(screen.getByTestId('aha-moment-skip'))
+    expect(onSkip).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the overlay container', () => {
+    render(<RunnerIdentityMoment identity={mockIdentity} onCTA={onCTA} onSkip={onSkip} />)
+    expect(screen.getByTestId('aha-moment-overlay')).toBeInTheDocument()
+  })
+})

--- a/v0/components/runner-identity-moment.tsx
+++ b/v0/components/runner-identity-moment.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useEffect } from 'react'
+import { cn } from '@/lib/utils'
+import { trackOnboardingEvent } from '@/lib/analytics'
+import { AhaMomentOverlay } from './aha-moment-overlay'
+import type { RunnerIdentity } from '@/lib/userInsightService'
+
+interface RunnerIdentityMomentProps {
+  identity: RunnerIdentity
+  onCTA: () => void
+  onSkip: () => void
+}
+
+export function RunnerIdentityMoment({ identity, onCTA, onSkip }: RunnerIdentityMomentProps) {
+  useEffect(() => {
+    void trackOnboardingEvent('aha_moment_fired', {
+      moment_id: 'knows_me',
+      variant: 'C',
+      identity_id: identity.id,
+    })
+  }, [identity.id])
+
+  const handleCTA = () => {
+    void trackOnboardingEvent('aha_moment_cta_clicked', {
+      moment_id: 'knows_me',
+      variant: 'C',
+      identity_id: identity.id,
+    })
+    onCTA()
+  }
+
+  const handleSkip = () => {
+    void trackOnboardingEvent('aha_moment_dismissed', {
+      moment_id: 'knows_me',
+      variant: 'C',
+      identity_id: identity.id,
+    })
+    onSkip()
+  }
+
+  return (
+    <AhaMomentOverlay
+      headline={identity.headline}
+      subline={identity.subline}
+      ctaLabel={identity.ctaLabel}
+      onCTA={handleCTA}
+      onSkip={handleSkip}
+    >
+      <div className="flex flex-col items-center gap-3">
+        <div
+          data-testid="identity-glyph"
+          className="text-6xl leading-none"
+          aria-hidden="true"
+        >
+          {identity.glyph}
+        </div>
+        <div
+          className={cn(
+            'px-4 py-1.5 rounded-full border text-sm font-semibold',
+            'bg-white/5',
+            identity.accentColor,
+            `ring-2 ${identity.ringColor}`
+          )}
+        >
+          {identity.label}
+        </div>
+      </div>
+    </AhaMomentOverlay>
+  )
+}

--- a/v0/components/runner-identity-moment.tsx
+++ b/v0/components/runner-identity-moment.tsx
@@ -22,6 +22,7 @@ export function RunnerIdentityMoment({ identity, onCTA, onSkip }: RunnerIdentity
   }, [identity.id])
 
   const handleCTA = () => {
+    // fire-and-forget: navigation may proceed before event resolves
     void trackOnboardingEvent('aha_moment_cta_clicked', {
       moment_id: 'knows_me',
       variant: 'C',
@@ -31,6 +32,7 @@ export function RunnerIdentityMoment({ identity, onCTA, onSkip }: RunnerIdentity
   }
 
   const handleSkip = () => {
+    // fire-and-forget: navigation may proceed before event resolves
     void trackOnboardingEvent('aha_moment_dismissed', {
       moment_id: 'knows_me',
       variant: 'C',

--- a/v0/lib/achievementDetector.test.ts
+++ b/v0/lib/achievementDetector.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { detectAchievement } from './achievementDetector'
+import { dbUtils } from '@/lib/dbUtils'
+
+vi.mock('@/lib/dbUtils', () => ({
+  dbUtils: {
+    getRunsByUser: vi.fn(),
+  },
+}))
+
+const mockGetRunsByUser = vi.mocked(dbUtils.getRunsByUser)
+
+describe('detectAchievement', () => {
+  beforeEach(() => {
+    mockGetRunsByUser.mockReset()
+  })
+
+  it('returns first_run when there are no prior runs', async () => {
+    mockGetRunsByUser.mockResolvedValue([{ id: 10, distance: 3.2 } as any])
+
+    const result = await detectAchievement(1, 10, 3.2)
+    expect(result).toEqual({ type: 'first_run', distanceKm: 3.2 })
+  })
+
+  it('returns milestone when crossing 5K for the first time', async () => {
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 11, distance: 5.1 } as any,
+      { id: 10, distance: 4.5 } as any,
+    ])
+
+    const result = await detectAchievement(1, 11, 5.1)
+    expect(result).toEqual({
+      type: 'milestone',
+      distanceKm: 5.1,
+      milestoneKm: 5,
+    })
+  })
+
+  it('returns personal_best when distance exceeds prior max', async () => {
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 12, distance: 4.5 } as any,
+      { id: 10, distance: 4.0 } as any,
+    ])
+
+    const result = await detectAchievement(1, 12, 4.5)
+    expect(result).toEqual({
+      type: 'personal_best',
+      distanceKm: 4.5,
+      previousBestKm: 4.0,
+    })
+  })
+
+  it('returns null when current distance is not an achievement', async () => {
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 13, distance: 3.5 } as any,
+      { id: 10, distance: 4.0 } as any,
+    ])
+
+    const result = await detectAchievement(1, 13, 3.5)
+    expect(result).toBeNull()
+  })
+})

--- a/v0/lib/achievementDetector.ts
+++ b/v0/lib/achievementDetector.ts
@@ -1,0 +1,39 @@
+import { dbUtils } from '@/lib/dbUtils'
+
+export type AchievementContext =
+  | { type: 'first_run'; distanceKm: number }
+  | { type: 'personal_best'; distanceKm: number; previousBestKm: number }
+  | { type: 'milestone'; distanceKm: number; milestoneKm: 5 | 10 | 21.1 }
+
+const MILESTONES: Array<5 | 10 | 21.1> = [5, 10, 21.1]
+
+export async function detectAchievement(
+  userId: number,
+  currentRunId: number,
+  currentDistanceKm: number
+): Promise<AchievementContext | null> {
+  const runs = await dbUtils.getRunsByUser(userId)
+  const priorRuns = runs.filter((run) => run.id !== currentRunId)
+
+  if (priorRuns.length === 0) {
+    return { type: 'first_run', distanceKm: currentDistanceKm }
+  }
+
+  const maxPriorDistance = Math.max(...priorRuns.map((run) => run.distance))
+
+  for (const milestone of MILESTONES) {
+    if (currentDistanceKm >= milestone && maxPriorDistance < milestone) {
+      return { type: 'milestone', distanceKm: currentDistanceKm, milestoneKm: milestone }
+    }
+  }
+
+  if (currentDistanceKm > maxPriorDistance) {
+    return {
+      type: 'personal_best',
+      distanceKm: currentDistanceKm,
+      previousBestKm: maxPriorDistance,
+    }
+  }
+
+  return null
+}

--- a/v0/lib/contextDetector.test.ts
+++ b/v0/lib/contextDetector.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { detectNoticeContext } from './contextDetector'
+import { dbUtils, hasAhaMomentFired, isNoticedMomentOnCooldown } from '@/lib/dbUtils'
+
+vi.mock('@/lib/dbUtils', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/dbUtils')>('@/lib/dbUtils')
+  return {
+    ...actual,
+    dbUtils: {
+      getRunsByUser: vi.fn(),
+    },
+    hasAhaMomentFired: vi.fn(),
+    isNoticedMomentOnCooldown: vi.fn(),
+  }
+})
+
+const mockGetRunsByUser = vi.mocked(dbUtils.getRunsByUser)
+const mockHasAhaMomentFired = vi.mocked(hasAhaMomentFired)
+const mockIsNoticedMomentOnCooldown = vi.mocked(isNoticedMomentOnCooldown)
+
+const baseRun = {
+  id: 100,
+  userId: 1,
+  distanceKm: 5,
+  durationSeconds: 1800,
+  startedAt: new Date('2026-06-10T12:00:00'),
+  paceMinPerKm: 6,
+}
+
+describe('detectNoticeContext', () => {
+  beforeEach(() => {
+    mockGetRunsByUser.mockReset()
+    mockHasAhaMomentFired.mockReset()
+    mockIsNoticedMomentOnCooldown.mockReset()
+    mockIsNoticedMomentOnCooldown.mockResolvedValue(false)
+    mockHasAhaMomentFired.mockResolvedValue(false)
+  })
+
+  it('returns null when cooldown is active', async () => {
+    mockIsNoticedMomentOnCooldown.mockResolvedValue(true)
+
+    const result = await detectNoticeContext(baseRun)
+    expect(result).toBeNull()
+  })
+
+  it('returns streak when streak milestone is reached and not already fired', async () => {
+    const today = new Date()
+    const dates = Array.from({ length: 7 }, (_, index) => {
+      const date = new Date(today)
+      date.setDate(today.getDate() - index)
+      return { id: index + 1, completedAt: date }
+    })
+
+    mockGetRunsByUser.mockResolvedValue(dates as any)
+    mockHasAhaMomentFired.mockResolvedValue(false)
+
+    const result = await detectNoticeContext(baseRun)
+    expect(result).toEqual({ type: 'streak', days: 7 })
+  })
+
+  it('returns comeback when last run was 10 days ago', async () => {
+    const tenDaysAgo = new Date()
+    tenDaysAgo.setDate(tenDaysAgo.getDate() - 10)
+
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 100, completedAt: baseRun.startedAt, distance: 5, duration: 1800 },
+      { id: 99, completedAt: tenDaysAgo, distance: 4, duration: 1500 },
+    ] as any)
+
+    const result = await detectNoticeContext(baseRun)
+    expect(result).toEqual({ type: 'comeback', daysSince: 10 })
+  })
+
+  it('returns high_effort when pace is 12% faster than average', async () => {
+    const recentDate = new Date()
+    recentDate.setDate(recentDate.getDate() - 2)
+
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 100, completedAt: baseRun.startedAt, distance: 5, duration: 1500 },
+      { id: 1, completedAt: recentDate, distance: 5, duration: 1800 },
+      { id: 2, completedAt: recentDate, distance: 5, duration: 1800 },
+      { id: 3, completedAt: recentDate, distance: 5, duration: 1800 },
+    ] as any)
+
+    const result = await detectNoticeContext({
+      ...baseRun,
+      paceMinPerKm: 5.28,
+    })
+
+    expect(result).toEqual({ type: 'high_effort', percentAbove: 12 })
+  })
+
+  it('returns early_morning for a 5:47am run', async () => {
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 100, completedAt: new Date('2026-06-10T05:47:00'), distance: 3, duration: 1200 },
+    ] as any)
+
+    const result = await detectNoticeContext({
+      ...baseRun,
+      startedAt: new Date('2026-06-10T05:47:00'),
+    })
+
+    expect(result?.type).toBe('early_morning')
+  })
+
+  it('returns null when no context matches', async () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    mockGetRunsByUser.mockResolvedValue([
+      { id: 100, completedAt: baseRun.startedAt, distance: 5, duration: 1800 },
+      { id: 99, completedAt: yesterday, distance: 4, duration: 1500 },
+    ] as any)
+
+    const result = await detectNoticeContext(baseRun)
+    expect(result).toBeNull()
+  })
+})

--- a/v0/lib/contextDetector.ts
+++ b/v0/lib/contextDetector.ts
@@ -1,0 +1,116 @@
+import { dbUtils, hasAhaMomentFired, isNoticedMomentOnCooldown } from '@/lib/dbUtils'
+
+export type NoticeContext =
+  | { type: 'streak'; days: 3 | 7 | 14 | 30 | 60 | 100 }
+  | { type: 'comeback'; daysSince: number }
+  | { type: 'high_effort'; percentAbove: number }
+  | { type: 'early_morning'; startedAt: Date }
+  | { type: 'late_night'; startedAt: Date }
+  | { type: 'third_run_week' }
+
+interface RunInput {
+  id: number
+  userId: number
+  distanceKm: number
+  durationSeconds: number
+  startedAt: Date
+  paceMinPerKm?: number
+}
+
+const STREAK_MILESTONES = [3, 7, 14, 30, 60, 100] as const
+
+export async function detectNoticeContext(run: RunInput): Promise<NoticeContext | null> {
+  if (await isNoticedMomentOnCooldown(run.userId)) {
+    return null
+  }
+
+  const allRuns = await dbUtils.getRunsByUser(run.userId)
+  const priorRuns = allRuns.filter((stored) => stored.id !== run.id)
+
+  const runDates = allRuns.map((stored) => new Date(stored.completedAt))
+  const streak = computeStreak(runDates)
+
+  for (const milestone of [...STREAK_MILESTONES].reverse()) {
+    if (streak === milestone) {
+      const alreadyFired = await hasAhaMomentFired(run.userId, 'noticed', `streak_${milestone}`)
+      if (!alreadyFired) {
+        return { type: 'streak', days: milestone }
+      }
+    }
+  }
+
+  if (priorRuns.length > 0) {
+    const lastRun = priorRuns[0]
+    const daysSinceLast =
+      (run.startedAt.getTime() - new Date(lastRun.completedAt).getTime()) / 86400000
+    if (daysSinceLast >= 7) {
+      return { type: 'comeback', daysSince: Math.round(daysSinceLast) }
+    }
+  }
+
+  if (run.paceMinPerKm) {
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000)
+    const recentPacedRuns = priorRuns.filter((stored) => {
+      const completedAt = new Date(stored.completedAt)
+      return completedAt >= thirtyDaysAgo && stored.distance >= 0.05 && stored.duration > 0
+    })
+
+    if (recentPacedRuns.length >= 3) {
+      const avgPaceSecPerKm =
+        recentPacedRuns.reduce((sum, stored) => sum + stored.duration / stored.distance, 0) /
+        recentPacedRuns.length
+      const runPaceSecPerKm = run.paceMinPerKm * 60
+      const improvement = (avgPaceSecPerKm - runPaceSecPerKm) / avgPaceSecPerKm
+      if (improvement >= 0.08) {
+        return { type: 'high_effort', percentAbove: Math.round(improvement * 100) }
+      }
+    }
+  }
+
+  const hour = run.startedAt.getHours()
+  const minute = run.startedAt.getMinutes()
+  if (hour < 6 || (hour === 6 && minute === 0)) {
+    return { type: 'early_morning', startedAt: run.startedAt }
+  }
+  if (hour >= 21) {
+    return { type: 'late_night', startedAt: run.startedAt }
+  }
+
+  const weekStart = getWeekStart(run.startedAt)
+  const runsThisWeek = allRuns.filter((stored) => {
+    if (stored.id === run.id) return false
+    return new Date(stored.completedAt) >= weekStart
+  })
+
+  if (runsThisWeek.length >= 2) {
+    return { type: 'third_run_week' }
+  }
+
+  return null
+}
+
+function computeStreak(runDates: Date[]): number {
+  const days = [...new Set(runDates.map((date) => date.toISOString().slice(0, 10)))].sort().reverse()
+  const today = new Date().toISOString().slice(0, 10)
+  let streak = 0
+  let cursor = today
+  for (const day of days) {
+    if (day === cursor) {
+      streak++
+      const prev = new Date(cursor)
+      prev.setDate(prev.getDate() - 1)
+      cursor = prev.toISOString().slice(0, 10)
+    } else if (day < cursor) {
+      break
+    }
+  }
+  return streak
+}
+
+function getWeekStart(date: Date): Date {
+  const d = new Date(date)
+  const day = d.getDay()
+  d.setDate(d.getDate() - (day === 0 ? 6 : day - 1))
+  d.setHours(0, 0, 0, 0)
+  return d
+}

--- a/v0/lib/dbUtils.ts
+++ b/v0/lib/dbUtils.ts
@@ -34,6 +34,19 @@ import {
   migrateLocalDateToUTC
 } from './timezone-utils';
 import { SyncService } from './sync/sync-service';
+import { createClient } from './supabase/client';
+
+type AhaMomentId = 'knows_me' | 'achievement' | 'future_vision' | 'noticed';
+
+async function resolveAuthUserId(): Promise<string | null> {
+  try {
+    const supabase = createClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.user?.id ?? null;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Database Utilities - Comprehensive database operations with error handling
@@ -5226,7 +5239,87 @@ export const dbUtils = {
   createChallengeProgress,
   updateChallengeProgress,
   getChallengeProgressByPlan,
+
+  // Aha moments
+  recordAhaMoment,
+  hasAhaMomentFired,
+  isNoticedMomentOnCooldown,
 };
+
+export async function recordAhaMoment(params: {
+  userId: number
+  momentId: AhaMomentId
+  context?: string
+  variant?: string
+}) {
+  const authUserId = await resolveAuthUserId();
+  if (!authUserId) return;
+
+  const supabase = createClient();
+  const { error } = await supabase
+    .from('user_aha_moments')
+    .upsert(
+      {
+        user_id: authUserId,
+        moment_id: params.momentId,
+        context: params.context ?? null,
+        variant: params.variant ?? null,
+      },
+      { onConflict: 'user_id,moment_id,context', ignoreDuplicates: true }
+    );
+
+  if (error) {
+    console.warn('[recordAhaMoment] failed silently:', error.message);
+  }
+}
+
+export async function hasAhaMomentFired(
+  _userId: number,
+  momentId: string,
+  context?: string
+): Promise<boolean> {
+  const authUserId = await resolveAuthUserId();
+  if (!authUserId) return false;
+
+  const supabase = createClient();
+  let query = supabase
+    .from('user_aha_moments')
+    .select('id')
+    .eq('user_id', authUserId)
+    .eq('moment_id', momentId);
+
+  if (context) {
+    query = query.eq('context', context);
+  }
+
+  const { data, error } = await query.limit(1).maybeSingle();
+  if (error) {
+    console.warn('[hasAhaMomentFired] failed silently:', error.message);
+    return false;
+  }
+
+  return Boolean(data);
+}
+
+export async function isNoticedMomentOnCooldown(_userId: number): Promise<boolean> {
+  const authUserId = await resolveAuthUserId();
+  if (!authUserId) return false;
+
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('user_aha_moments')
+    .select('fired_at')
+    .eq('user_id', authUserId)
+    .eq('moment_id', 'noticed')
+    .order('fired_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data?.fired_at) return false;
+
+  const daysSinceLast = (Date.now() - new Date(data.fired_at).getTime()) / 86400000;
+  return daysSinceLast < 3;
+}
 
 export default dbUtils;
 export { seedDemoRoutes } from './seedRoutes';

--- a/v0/lib/userInsightService.test.ts
+++ b/v0/lib/userInsightService.test.ts
@@ -39,11 +39,11 @@ describe('getRunningIdentity', () => {
   it('returns an identity with all required fields', () => {
     const result = getRunningIdentity('distance', 'occasional', 7.0)
     expect(result.id).toBeDefined()
-    expect(result.label).toBeTruthy()
-    expect(result.glyph).toBeTruthy()
-    expect(result.headline).toBeTruthy()
-    expect(result.subline).toBeTruthy()
-    expect(result.ctaLabel).toBeTruthy()
+    expect(result.label.trim().length).toBeGreaterThan(0)
+    expect(result.glyph.trim().length).toBeGreaterThan(0)
+    expect(result.headline.trim().length).toBeGreaterThan(0)
+    expect(result.subline.trim().length).toBeGreaterThan(0)
+    expect(result.ctaLabel.trim().length).toBeGreaterThan(0)
   })
 })
 
@@ -73,9 +73,9 @@ describe('projectGoalTimeline', () => {
     expect(result.milestoneWeek).toBe(4)
   })
 
-  it('milestoneWeek is at least 1', () => {
-    const result = projectGoalTimeline('habit', 'regular')
-    expect(result.milestoneWeek).toBeGreaterThanOrEqual(1)
+  it('milestoneWeek is half of weeks rounded down', () => {
+    const result = projectGoalTimeline('habit', 'regular') // 3 weeks → milestoneWeek = 1
+    expect(result.milestoneWeek).toBe(1)
   })
 
   it('projectedDate is in the future', () => {
@@ -84,10 +84,11 @@ describe('projectGoalTimeline', () => {
   })
 
   it('projectedDate is approximately weeks * 7 days from now', () => {
+    const before = Date.now()
     const result = projectGoalTimeline('distance', 'beginner')
     const expectedMs = result.weeks * 7 * 24 * 60 * 60 * 1000
-    const actualMs = result.projectedDate.getTime() - Date.now()
-    expect(actualMs).toBeGreaterThan(expectedMs - 5000) // within 5 seconds
+    const actualMs = result.projectedDate.getTime() - before
+    expect(actualMs).toBeGreaterThan(expectedMs - 5000)
     expect(actualMs).toBeLessThan(expectedMs + 5000)
   })
 
@@ -105,7 +106,7 @@ describe('projectGoalTimeline', () => {
 
   it('returns goalLabel and milestoneLabel strings', () => {
     const result = projectGoalTimeline('distance', 'beginner')
-    expect(result.goalLabel).toBeTruthy()
-    expect(result.milestoneLabel).toBeTruthy()
+    expect(result.goalLabel.trim().length).toBeGreaterThan(0)
+    expect(result.milestoneLabel.trim().length).toBeGreaterThan(0)
   })
 })

--- a/v0/lib/userInsightService.test.ts
+++ b/v0/lib/userInsightService.test.ts
@@ -1,0 +1,111 @@
+// v0/lib/userInsightService.test.ts
+import { describe, it, expect } from 'vitest'
+import {
+  getRunningIdentity,
+  projectGoalTimeline,
+} from './userInsightService'
+
+describe('getRunningIdentity', () => {
+  it('returns first_timer for beginners regardless of pace or goal', () => {
+    const result = getRunningIdentity('distance', 'beginner', 7.0)
+    expect(result.id).toBe('first_timer')
+  })
+
+  it('returns first_timer for beginners even with fast pace', () => {
+    const result = getRunningIdentity('speed', 'beginner', 4.5)
+    expect(result.id).toBe('first_timer')
+  })
+
+  it('returns speed_seeker when goal is speed and experience is not beginner', () => {
+    const result = getRunningIdentity('speed', 'regular', 6.0)
+    expect(result.id).toBe('speed_seeker')
+  })
+
+  it('returns speed_seeker when pace is below 5.5 min/km', () => {
+    const result = getRunningIdentity('distance', 'regular', 5.2)
+    expect(result.id).toBe('speed_seeker')
+  })
+
+  it('returns endurance_builder when goal is distance and pace is above 6.5 min/km', () => {
+    const result = getRunningIdentity('distance', 'occasional', 7.0)
+    expect(result.id).toBe('endurance_builder')
+  })
+
+  it('returns balanced_athlete for regular runners with moderate pace and habit goal', () => {
+    const result = getRunningIdentity('habit', 'regular', 6.0)
+    expect(result.id).toBe('balanced_athlete')
+  })
+
+  it('returns an identity with all required fields', () => {
+    const result = getRunningIdentity('distance', 'occasional', 7.0)
+    expect(result.id).toBeDefined()
+    expect(result.label).toBeTruthy()
+    expect(result.glyph).toBeTruthy()
+    expect(result.headline).toBeTruthy()
+    expect(result.subline).toBeTruthy()
+    expect(result.ctaLabel).toBeTruthy()
+  })
+})
+
+describe('projectGoalTimeline', () => {
+  it('returns 4 weeks for a beginner with habit goal', () => {
+    const result = projectGoalTimeline('habit', 'beginner')
+    expect(result.weeks).toBe(4)
+  })
+
+  it('returns 8 weeks for a beginner with distance goal', () => {
+    const result = projectGoalTimeline('distance', 'beginner')
+    expect(result.weeks).toBe(8)
+  })
+
+  it('returns 5 weeks for a regular runner with distance goal', () => {
+    const result = projectGoalTimeline('distance', 'regular')
+    expect(result.weeks).toBe(5)
+  })
+
+  it('returns 3 weeks for a regular runner with habit goal', () => {
+    const result = projectGoalTimeline('habit', 'regular')
+    expect(result.weeks).toBe(3)
+  })
+
+  it('sets milestoneWeek to roughly half the weeks', () => {
+    const result = projectGoalTimeline('distance', 'beginner')
+    expect(result.milestoneWeek).toBe(4)
+  })
+
+  it('milestoneWeek is at least 1', () => {
+    const result = projectGoalTimeline('habit', 'regular')
+    expect(result.milestoneWeek).toBeGreaterThanOrEqual(1)
+  })
+
+  it('projectedDate is in the future', () => {
+    const result = projectGoalTimeline('distance', 'beginner')
+    expect(result.projectedDate.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('projectedDate is approximately weeks * 7 days from now', () => {
+    const result = projectGoalTimeline('distance', 'beginner')
+    const expectedMs = result.weeks * 7 * 24 * 60 * 60 * 1000
+    const actualMs = result.projectedDate.getTime() - Date.now()
+    expect(actualMs).toBeGreaterThan(expectedMs - 5000) // within 5 seconds
+    expect(actualMs).toBeLessThan(expectedMs + 5000)
+  })
+
+  it('uses beginner as fallback for unknown experience', () => {
+    const known = projectGoalTimeline('distance', 'beginner')
+    const unknown = projectGoalTimeline('distance', 'unknown_experience')
+    expect(unknown.weeks).toBe(known.weeks)
+  })
+
+  it('uses habit as fallback for unknown goal', () => {
+    const known = projectGoalTimeline('habit', 'beginner')
+    const unknown = projectGoalTimeline('unknown_goal', 'beginner')
+    expect(unknown.weeks).toBe(known.weeks)
+  })
+
+  it('returns goalLabel and milestoneLabel strings', () => {
+    const result = projectGoalTimeline('distance', 'beginner')
+    expect(result.goalLabel).toBeTruthy()
+    expect(result.milestoneLabel).toBeTruthy()
+  })
+})

--- a/v0/lib/userInsightService.ts
+++ b/v0/lib/userInsightService.ts
@@ -1,0 +1,127 @@
+// v0/lib/userInsightService.ts
+
+export type RunnerIdentityId =
+  | 'endurance_builder'
+  | 'speed_seeker'
+  | 'first_timer'
+  | 'balanced_athlete'
+
+export interface RunnerIdentity {
+  id: RunnerIdentityId
+  label: string
+  glyph: string
+  accentColor: string // Tailwind text color class
+  ringColor: string   // Tailwind ring color class
+  headline: string
+  subline: string
+  ctaLabel: string
+}
+
+export interface GoalTimeline {
+  weeks: number
+  milestoneWeek: number
+  milestoneLabel: string
+  goalLabel: string
+  projectedDate: Date
+}
+
+const IDENTITIES: Record<RunnerIdentityId, RunnerIdentity> = {
+  endurance_builder: {
+    id: 'endurance_builder',
+    label: 'Endurance Builder',
+    glyph: '⛰️',
+    accentColor: 'text-emerald-400',
+    ringColor: 'ring-emerald-400/40',
+    headline: "We can already tell — you're in it for the miles, not the medals.",
+    subline: "That's the kind of runner who surprises themselves. Let's find out how far.",
+    ctaLabel: "I'm ready",
+  },
+  speed_seeker: {
+    id: 'speed_seeker',
+    label: 'Speed Seeker',
+    glyph: '⚡',
+    accentColor: 'text-orange-400',
+    ringColor: 'ring-orange-400/40',
+    headline: "You're chasing time, not just distance.",
+    subline: "Every second you shave off is earned. We'll help you earn more of them.",
+    ctaLabel: "Let's go faster",
+  },
+  first_timer: {
+    id: 'first_timer',
+    label: 'First Timer',
+    glyph: '🌱',
+    accentColor: 'text-sky-400',
+    ringColor: 'ring-sky-400/40',
+    headline: "Everyone starts somewhere. Yours starts now.",
+    subline: "The runners who stick with it are the ones who start slowly. We've got you.",
+    ctaLabel: "Start my journey",
+  },
+  balanced_athlete: {
+    id: 'balanced_athlete',
+    label: 'All-Round Runner',
+    glyph: '🏃',
+    accentColor: 'text-teal-400',
+    ringColor: 'ring-teal-400/40',
+    headline: "You've got a good base. Let's do something with it.",
+    subline: "Consistent runners who mix pace and distance improve fastest. That's your path.",
+    ctaLabel: "Build on it",
+  },
+}
+
+const WEEKS_TO_GOAL: Record<string, Record<string, number>> = {
+  habit:    { beginner: 4, occasional: 4, regular: 3 },
+  distance: { beginner: 8, occasional: 6, regular: 5 },
+  speed:    { beginner: 6, occasional: 5, regular: 4 },
+}
+
+const MILESTONE_LABELS: Record<string, string> = {
+  habit:    'First consistent week',
+  distance: 'Halfway there',
+  speed:    'Feeling the difference',
+}
+
+const GOAL_LABELS: Record<string, string> = {
+  habit:    'Running 3× / week',
+  distance: 'New distance goal',
+  speed:    'Faster than today',
+}
+
+/**
+ * Classify a runner's identity from onboarding data.
+ * paceMinPerKm is referenceRaceTimeSeconds / 60 / referenceRaceDistanceKm.
+ */
+export function getRunningIdentity(
+  goal: string,
+  experience: string,
+  paceMinPerKm: number
+): RunnerIdentity {
+  if (experience === 'beginner') return IDENTITIES.first_timer
+  if (goal === 'speed' || paceMinPerKm < 5.5) return IDENTITIES.speed_seeker
+  if (goal === 'distance' && paceMinPerKm > 6.5) return IDENTITIES.endurance_builder
+  return IDENTITIES.balanced_athlete
+}
+
+/**
+ * Project when the user will reach their goal based on onboarding data.
+ */
+export function projectGoalTimeline(
+  goal: string,
+  experience: string,
+): GoalTimeline {
+  const normalizedGoal = goal in WEEKS_TO_GOAL ? goal : 'habit'
+  const normalizedExp = experience in (WEEKS_TO_GOAL[normalizedGoal] ?? {}) ? experience : 'beginner'
+
+  const weeks = WEEKS_TO_GOAL[normalizedGoal]![normalizedExp]!
+  const milestoneWeek = Math.max(1, Math.floor(weeks / 2))
+
+  const projectedDate = new Date()
+  projectedDate.setDate(projectedDate.getDate() + weeks * 7)
+
+  return {
+    weeks,
+    milestoneWeek,
+    milestoneLabel: MILESTONE_LABELS[normalizedGoal] ?? 'Milestone',
+    goalLabel: GOAL_LABELS[normalizedGoal] ?? 'Your goal',
+    projectedDate,
+  }
+}

--- a/v0/supabase/migrations/20260610000000_user_aha_moments.sql
+++ b/v0/supabase/migrations/20260610000000_user_aha_moments.sql
@@ -1,0 +1,20 @@
+-- Run via: supabase db push or Supabase dashboard
+
+CREATE TABLE IF NOT EXISTS user_aha_moments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID REFERENCES auth.users NOT NULL,
+  moment_id     TEXT NOT NULL,
+  context       TEXT,
+  variant       TEXT,
+  fired_at      TIMESTAMPTZ DEFAULT NOW(),
+  cta_clicked   BOOLEAN DEFAULT FALSE,
+  dismissed_at  TIMESTAMPTZ,
+  shared        BOOLEAN DEFAULT FALSE,
+  UNIQUE(user_id, moment_id, context)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_aha_moments_user_id ON user_aha_moments(user_id);
+
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS runner_identity TEXT;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS goal_timeline_weeks INTEGER;
+ALTER TABLE profiles ADD COLUMN IF NOT EXISTS projected_goal_date DATE;


### PR DESCRIPTION
## Summary
- Adds `RunnerIdentityMoment` (Aha #1) and `GoalTimelineMoment` (Aha #3) wired into onboarding flow
- Adds Phase 2+3: post-run achievement overlay + noticed coaching moment
- Adds `AhaMomentOverlay` shared shell component
- Strengthens userInsightService test assertions

## Status
Branch is complete and lint-clean. Holding for post-submission merge decision — both apps are currently in App Store review.

## Test plan
- [ ] Onboarding flow triggers Aha #1 (RunnerIdentityMoment) at correct step
- [ ] Onboarding flow triggers Aha #3 (GoalTimelineMoment) at correct step
- [ ] Post-run overlay (Aha #2) appears after first completed run
- [ ] Noticed coaching moment fires on correct condition
- [ ] All existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice coaching cues during runs.
  * Achievement celebration overlays for first runs, personal bests, and milestone distances.
  * Runner identity classification and goal timeline visualization during onboarding.
  * Context-aware coaching moments on run reports (streaks, comebacks, high effort, time of day).
  * Moment tracking persistence.

* **Tests**
  * Added comprehensive test coverage for new components and detection logic.

* **Documentation**
  * Implementation phases and database design documentation for achievement system.
  * Failed approaches and decision logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->