### PR TITLE
feat(garmin): lock down worker import-job RPCs to service_role

### DIFF
--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -2,15 +2,14 @@
 
 Project: RunSmart Web
 Status: Active
-Current Phase: Today page improvement planning, post Aha Moments merge
-Active Story: Story 1: Today Content Inventory and Preservation Map (see tasks/todo.md)
-Last Completed Story: Aha Moments merged via PR #90 (2026-06-10); Session End Rule docs via PR #91 (2026-06-11)
-Next Recommended Story: Implement Story 1 (Today content inventory and preservation map) before any Today redesign work
-Estimated Completion: Today redesign not started; Story 1 is the entry point
-Blockers: —
-Risks: Missing a current Today item because the page is composed through nested components; scope creep from inventory into redesign implementation
-Last Validation: npm run lint passed (0 errors, 1648 warnings) and npm run type-check (tsc --noEmit) passed in v0/ on 2026-06-12, after npm ci restored node_modules to the lockfile.
-Last Updated: 2026-06-12
+Current Phase: Garmin production enablement (web/backend audit + hardening)
+Active Story: Garmin worker-RPC grant lockdown migration (written, awaiting founder approval to apply)
+Last Completed Story: Garmin production-enablement audit (2026-06-21): cleared stranded branch fix/garmin-ios-branch-fixes (fully landed via PR #94, deleted local), confirmed Gate 1 privacy policy live in code, webhook async-200 + deregistration handler verified, table grants confirmed scoped
+Next Recommended Story: Founder approval to apply migration 20260621000000_restrict_garmin_worker_rpc_grants.sql; then manual Gate 2/3/4 portal+email tasks (see tasks/work-pack-garmin-gate-1-4.md)
+Estimated Completion: Web/backend code is production-ready; remaining gates are Garmin-portal/email/manual founder tasks
+Blockers: Migration apply needs founder "yes" (no DB push without approval). Garmin Production approval is external (~2-4 weeks after submission).
+Risks: Worker RPCs (claim/requeue/fail_garmin_import_job) are SECURITY DEFINER and PUBLIC-executable until the lockdown migration is applied; SECURITY DEFINER functions also lack set search_path (noted follow-up)
+Last Validation: 15/15 Garmin route tests pass (webhook, activities, sleep) via npx vitest in v0/ on 2026-06-21. Migration not yet applied.
 Latest QA Report: —
 
 <!--

--- a/v0/supabase/migrations/20260621000000_restrict_garmin_worker_rpc_grants.sql
+++ b/v0/supabase/migrations/20260621000000_restrict_garmin_worker_rpc_grants.sql
@@ -1,0 +1,22 @@
+-- Restrict execute privileges on Garmin import-worker RPCs.
+--
+-- claim_garmin_import_jobs / requeue_garmin_import_job / fail_garmin_import_job
+-- are SECURITY DEFINER functions that mutate public.garmin_import_jobs and bypass
+-- RLS. The worker invokes them only with the service_role key
+-- (see v0/lib/integrations/garmin/service.ts -> createAdminClient()).
+--
+-- Postgres grants EXECUTE on new functions to PUBLIC by default, which leaves
+-- anon and authenticated able to claim, requeue, or fail other users' import
+-- jobs. Lock execution down to service_role only. This mirrors the web-repo
+-- table grants (tables are already revoked from anon/authenticated) and the
+-- equivalent lockdown applied in the RunSmart iOS repo context.
+--
+-- REVOKE/GRANT are idempotent, so this migration is safe to re-run.
+
+revoke execute on function public.claim_garmin_import_jobs(integer, text) from public, anon, authenticated;
+revoke execute on function public.requeue_garmin_import_job(uuid, timestamptz, text) from public, anon, authenticated;
+revoke execute on function public.fail_garmin_import_job(uuid, text, boolean) from public, anon, authenticated;
+
+grant execute on function public.claim_garmin_import_jobs(integer, text) to service_role;
+grant execute on function public.requeue_garmin_import_job(uuid, timestamptz, text) to service_role;
+grant execute on function public.fail_garmin_import_job(uuid, text, boolean) to service_role;


### PR DESCRIPTION
## Summary

Garmin production-enablement work (web/backend). Two parts:

1. **Stranded branch cleared.** `fix/garmin-ios-branch-fixes` was fully landed via [PR #94](https://github.com/nadavyigal/Running-coach-/pull/94) (squash-merge left a different hash). Its only unique content (the Gate 1-4 work pack) is already on `main`; all code fixes are ancestors of `main`. Deleted the local branch — no stranded work remains.

2. **Worker-RPC grant lockdown migration** (`20260621000000_restrict_garmin_worker_rpc_grants.sql`). `claim_garmin_import_jobs`, `requeue_garmin_import_job`, and `fail_garmin_import_job` are `SECURITY DEFINER` functions that bypass RLS and mutate `garmin_import_jobs`. The worker calls them only via the `service_role` admin client, but Postgres' default `PUBLIC` EXECUTE grant left `anon`/`authenticated` able to invoke them. This migration revokes from `public/anon/authenticated` and grants to `service_role` only — mirroring the already-scoped table grants and the equivalent lockdown applied in the iOS repo context.

## Garmin enablement audit (no code change needed)

- **Gate 1 (privacy):** live in code — `v0/app/privacy/page.tsx` has the `#garmin-connect-data` anchor, Garmin section, and OpenAI disclosure.
- **Gate 2 (webhook):** `webhook/route.ts` returns async 200 immediately and processes off the response path; deregistration handled via `handleGarminUserDeregistrations`; path-token variant survives portal round-trips.
- **Table grants:** already revoked from `anon`/`authenticated`, scoped to `authenticated`/`service_role`.
- **No env feature-flag gate** for Garmin exists (gated by env credentials + user connection). Flag if a kill-switch is wanted.

## Founder decisions required (not done here)

- ⚠️ **Apply the migration to production** — needs explicit approval (no DB push without "yes").
- Manual Gate 2/3/4 portal/email tasks (Data Generator test, API Blog signup, team email hygiene, screenshots, send evidence to Marc Lussi) per `tasks/work-pack-garmin-gate-1-4.md`.

## Testing

- 15/15 Garmin route tests pass (`webhook`, `activities`, `sleep`) via `npx vitest` in `v0/`.
- Migration not yet applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted access to Garmin import worker functions to prevent unauthorized execution, ensuring only authorized service components can perform these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->