### PR TITLE
Route subagents to model tiers by task complexity (#4)

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,6 +1,7 @@
 ---
 name: Architect
 description: Checks system design fit before multi-file changes. Use before modifying shared utilities, DB schema, API contracts, or introducing new dependencies. Outputs architecture notes or ADR entries.
+model: claude-opus-4-8
 ---
 
 # Architect Agent — RunSmart

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: Code Reviewer
 description: Reviews implementation diffs for regressions, unrelated changes, removed tests, and security issues. Use after every implementation, before the done declaration.
+model: claude-sonnet-4-6
 ---
 
 # Code Reviewer Agent — RunSmart

--- a/.claude/agents/director.md
+++ b/.claude/agents/director.md
@@ -1,6 +1,7 @@
 ---
 name: Director
 description: Session owner. Activates at the start of every coding session to confirm scope, sequence stories, and declare done. Use when starting any non-trivial task or when implementation has completed and needs a final quality gate.
+model: claude-sonnet-4-6
 ---
 
 # Director Agent — RunSmart

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,6 +1,7 @@
 ---
 name: Product Manager
 description: Clarifies user value and acceptance criteria. Use when a task description is vague, when there is no clear success definition, or when proposed implementation doesn't map to a real user need.
+model: claude-sonnet-4-6
 ---
 
 # Product Manager Agent — RunSmart

--- a/.claude/agents/qa-tdd.md
+++ b/.claude/agents/qa-tdd.md
@@ -1,6 +1,7 @@
 ---
 name: QA / TDD
 description: Defines test plans before implementation and verifies behavior after. Use before any implementation to define what tests are needed, and after implementation to run tests and report results.
+model: claude-sonnet-4-6
 ---
 
 # QA / TDD Agent — RunSmart

--- a/.claude/agents/scrum-master.md
+++ b/.claude/agents/scrum-master.md
@@ -1,6 +1,7 @@
 ---
 name: Scrum Master
 description: Breaks complex tasks into small, ordered, independently-deliverable stories. Use when a task has more than one implementation step. Enforces the one-story-at-a-time rule.
+model: claude-haiku-4-5-20251001
 ---
 
 # Scrum Master Agent — RunSmart


### PR DESCRIPTION
Benchmark item #4 (model routing), grounded in the #3 cost data: Opus was ~83% of spend, and these RunSmart subagents all **inherited the session model** (Opus) — paying premium rates for mechanical work.

Pin each by task complexity (the paper's principle: reserve the top model for architecture, route mechanical work down):

| Agent | Model | Why |
|---|---|---|
| architect | opus | architecture/design decisions |
| code-reviewer | sonnet | review |
| director | sonnet | coordination |
| product-manager | sonnet | specs/stories |
| qa-tdd | sonnet | test plans |
| scrum-master | haiku | most mechanical: story breakdown / process |

`ios-expert` left inheriting (no YAML frontmatter; it's a persona doc).

No behavior/correctness change to product code — only which model these agents run on. Tune freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)