### PR TITLE
[codex] Add RunSmart PostHog LLM observability

### DIFF
--- a/services/worker/src/jobs/ai-activity.ts
+++ b/services/worker/src/jobs/ai-activity.ts
@@ -5,6 +5,7 @@ import sharp from 'sharp';
 import { z } from 'zod';
 import type { AiActivityJobData, AiActivityResult } from '../../shared/types/jobs';
 import { logger } from '../utils/logger';
+import { captureAIGeneration } from '../utils/ai-observability';
 
 const activitySchema = z.object({
   type: z.string().optional(),
@@ -41,16 +42,35 @@ export async function processAiActivity(job: Job<AiActivityJobData>): Promise<Ai
     // Step 2: GPT-4o Vision analysis
     const imageUrl = `data:image/jpeg;base64,${processedImage.toString('base64')}`;
 
-    const { object: extracted } = await generateObject({
+    const prompt = 'Extract running activity data from this image';
+    const generationStartedAt = Date.now();
+    const generation = await generateObject({
       model: openai('gpt-4o'),
-      schema: activitySchema,
+      schema: activitySchema as any,
       messages: [{
         role: 'user',
         content: [
-          { type: 'text', text: 'Extract running activity data from this image' },
+          { type: 'text', text: prompt },
           { type: 'image', image: imageUrl }
         ]
       }]
+    });
+    const { object: extracted } = generation;
+
+    await captureAIGeneration({
+      traceName: 'ai-activity',
+      distinctId: userId,
+      model: 'gpt-4o',
+      input: prompt,
+      output: extracted,
+      usage: (generation as any).usage,
+      latencyMs: Date.now() - generationStartedAt,
+      properties: {
+        request_id: requestId,
+        job_id: job.id,
+        worker: true,
+        streaming: false
+      }
     });
 
     await job.updateProgress(90);
@@ -78,6 +98,20 @@ export async function processAiActivity(job: Job<AiActivityJobData>): Promise<Ai
     return result;
 
   } catch (error) {
+    await captureAIGeneration({
+      traceName: 'ai-activity',
+      distinctId: userId,
+      model: 'gpt-4o',
+      input: 'Extract running activity data from this image',
+      latencyMs: Date.now() - startTime,
+      error,
+      properties: {
+        request_id: requestId,
+        job_id: job.id,
+        worker: true,
+        streaming: false
+      }
+    });
     logger.error('AI activity failed', { jobId: job.id, error });
     throw error;
   }

--- a/services/worker/src/utils/ai-observability.ts
+++ b/services/worker/src/utils/ai-observability.ts
@@ -1,0 +1,115 @@
+type AIUsage = {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  inputTokens?: number
+  outputTokens?: number
+}
+
+type AIGenerationCaptureArgs = {
+  traceName: string
+  distinctId?: string | number | null
+  model: string
+  input: unknown
+  output?: unknown
+  usage?: AIUsage | null
+  latencyMs: number
+  error?: unknown
+  properties?: Record<string, unknown>
+}
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+const DATA_URL_PATTERN = /data:[^;,]+\/[^;,]+;base64,[A-Za-z0-9+/=]+/g
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+const PHONE_PATTERN = /(?:\+?\d[\d\s().-]{7,}\d)/g
+const CAPTURE_TIMEOUT_MS = 1500
+
+function getPostHogConfig(): { apiKey: string; host: string } | null {
+  const apiKey = process.env.POSTHOG_API_KEY?.trim() || ''
+
+  if (!apiKey) return null
+
+  const host = (
+    process.env.POSTHOG_HOST?.trim() ||
+    process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() ||
+    DEFAULT_POSTHOG_HOST
+  ).replace(/\/$/, '')
+
+  return { apiKey, host }
+}
+
+function redact(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return value
+      .replace(DATA_URL_PATTERN, '[redacted-data-url]')
+      .replace(EMAIL_PATTERN, '[redacted-email]')
+      .replace(PHONE_PATTERN, '[redacted-phone]')
+  }
+
+  if (Array.isArray(value)) return value.map(redact)
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, redact(item)])
+    )
+  }
+
+  return value
+}
+
+function usageNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function captureAIGeneration(args: AIGenerationCaptureArgs): Promise<void> {
+  const config = getPostHogConfig()
+  if (!config) return
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS)
+  const traceId = crypto.randomUUID()
+  const distinctId = args.distinctId !== undefined && args.distinctId !== null ? String(args.distinctId) : traceId
+  const inputTokens = usageNumber(args.usage?.promptTokens ?? args.usage?.inputTokens)
+  const outputTokens = usageNumber(args.usage?.completionTokens ?? args.usage?.outputTokens)
+  const totalTokens = usageNumber(args.usage?.totalTokens) || inputTokens + outputTokens
+  const outputChoices = args.output !== undefined ? [{ content: args.output }] : []
+
+  try {
+    await fetch(`${config.host}/capture/`, {
+      method: 'POST',
+      signal: controller.signal,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: config.apiKey,
+        event: '$ai_generation',
+        properties: {
+          distinct_id: distinctId,
+          $ai_lib: 'runsmart-worker-vercel-ai-sdk-manual',
+          $ai_provider: 'openai',
+          $ai_model: args.model,
+          $ai_model_parameters: {},
+          $ai_input: redact(args.input),
+          $ai_output_choices: redact(outputChoices),
+          $ai_http_status: args.error ? 500 : 200,
+          $ai_input_tokens: inputTokens,
+          $ai_output_tokens: outputTokens,
+          $ai_total_tokens: totalTokens,
+          $ai_latency: args.latencyMs,
+          $ai_trace_id: traceId,
+          $ai_trace_name: args.traceName,
+          $ai_is_error: Boolean(args.error),
+          ...(args.error ? { $ai_error: errorMessage(args.error) } : {}),
+          ...args.properties,
+        },
+      }),
+    })
+  } catch {
+    // Telemetry must not break background jobs.
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/v0/.env.example
+++ b/v0/.env.example
@@ -67,6 +67,10 @@ GARMIN_WEBHOOK_SECRET=
 # =============================================================================
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Server-side PostHog capture for AI observability.
+# Use the same project key as NEXT_PUBLIC_POSTHOG_KEY; keep it in server/runtime env only.
+POSTHOG_API_KEY=
+POSTHOG_HOST=https://us.i.posthog.com
 
 # =============================================================================
 # Other Configuration

--- a/v0/app/api/ai-activity/route.ts
+++ b/v0/app/api/ai-activity/route.ts
@@ -10,6 +10,7 @@ import {
   parseLocaleNumber,
   parsePaceToSecondsPerKm,
 } from "@/lib/activityParsing"
+import { captureAIGeneration } from "@/lib/ai-observability"
 
 // Use Node.js runtime for sharp image processing
 export const runtime = 'nodejs'
@@ -224,6 +225,7 @@ const validateAndNormalizeExtracted = (extracted: {
 
 export async function POST(req: Request) {
   const requestId = crypto.randomUUID()
+  const startedAt = Date.now()
 
   try {
     if (!process.env.OPENAI_API_KEY) {
@@ -363,8 +365,35 @@ export async function POST(req: Request) {
         ],
       })
       structuredRaw = structured.object
+      await captureAIGeneration({
+        traceName: "ai-activity",
+        model: PRIMARY_MODEL,
+        input: prompt,
+        output: structured.object,
+        usage: (structured as any).usage,
+        latencyMs: Date.now() - startedAt,
+        properties: {
+          request_id: requestId,
+          extraction_method: "vision_structured",
+          mime_type: preprocessed.mimeType,
+          streaming: false,
+        },
+      })
     } catch (error) {
       logger.warn("Structured vision extraction failed", { requestId, error })
+      await captureAIGeneration({
+        traceName: "ai-activity",
+        model: PRIMARY_MODEL,
+        input: prompt,
+        latencyMs: Date.now() - startedAt,
+        error,
+        properties: {
+          request_id: requestId,
+          extraction_method: "vision_structured",
+          mime_type: preprocessed.mimeType,
+          streaming: false,
+        },
+      })
     }
 
     let extracted = structuredRaw ? normalizeStructured(structuredRaw, preprocessed.exifDateIso) : null
@@ -397,6 +426,20 @@ export async function POST(req: Request) {
           : typeof rawOcrText === "function"
             ? String(rawOcrText())
             : ""
+      await captureAIGeneration({
+        traceName: "ai-activity",
+        model: OCR_FALLBACK_MODEL,
+        input: ocrPrompt,
+        output: ocrText,
+        usage: (ocrResult as any).usage,
+        latencyMs: Date.now() - startedAt,
+        properties: {
+          request_id: requestId,
+          extraction_method: "vision_text_fallback",
+          mime_type: preprocessed.mimeType,
+          streaming: false,
+        },
+      })
       const parsedFromText = parseActivityFromText(ocrText)
       extracted = {
         type: extracted?.type || "run",

--- a/v0/app/api/ai/garmin-insights/route.ts
+++ b/v0/app/api/ai/garmin-insights/route.ts
@@ -9,6 +9,7 @@ import {
   fetchLatestInsight,
   type GenerateGarminInsightRequest,
 } from "@/lib/server/garmin-insights-service"
+import { captureAIGeneration } from "@/lib/ai-observability"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -78,6 +79,9 @@ export async function GET(req: Request): Promise<Response> {
 }
 
 export async function POST(req: Request): Promise<Response> {
+  const requestId = `garmin_insight_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+  const startedAt = Date.now()
+
   if (!process.env.OPENAI_API_KEY?.trim()) {
     return NextResponse.json({ error: "OpenAI API key not configured", fallback: true }, { status: 503 })
   }
@@ -119,6 +123,31 @@ export async function POST(req: Request): Promise<Response> {
       ],
       maxOutputTokens: 220,
       temperature: 0.35,
+    })
+
+    void Promise.allSettled([
+      Promise.resolve((result as any).text ?? ""),
+      Promise.resolve((result as any).usage),
+    ]).then(([textResult, usageResult]) => {
+      const output = textResult.status === "fulfilled" ? textResult.value : ""
+      const usage = usageResult.status === "fulfilled" ? usageResult.value : undefined
+      return captureAIGeneration({
+        traceName: "garmin-insights",
+        distinctId: userId,
+        model: OPENAI_MODEL,
+        input: [
+          { role: "system", content: prompts.systemPrompt },
+          { role: "user", content: prompts.userPrompt },
+        ],
+        output,
+        usage,
+        latencyMs: Date.now() - startedAt,
+        properties: {
+          request_id: requestId,
+          streaming: true,
+          insight_type: insightType,
+        },
+      })
     })
 
     const streamResult = result as unknown as {

--- a/v0/app/api/chat/route.ts
+++ b/v0/app/api/chat/route.ts
@@ -152,28 +152,25 @@ export async function POST(req: Request): Promise<Response> {
             const chunk = `0:${JSON.stringify({ textDelta: text })}\n`
             controller.enqueue(encoder.encode(chunk))
           }
-          void Promise.resolve((result as any).usage)
-            .then((usage) =>
-              captureAIGeneration({
-                traceName: "chat",
-                distinctId: parsedUserId,
-                model: OPENAI_MODEL,
-                input: apiMessages,
-                output,
-                usage,
-                latencyMs: Date.now() - startedAt,
-                properties: {
-                  request_id: requestId,
-                  streaming: true,
-                  has_garmin_context: Boolean(garminContextSummary),
-                },
-              })
-            )
-            .catch(() => {})
+          const usage = await Promise.resolve((result as any).usage).catch(() => undefined)
+          await captureAIGeneration({
+            traceName: "chat",
+            distinctId: parsedUserId,
+            model: OPENAI_MODEL,
+            input: apiMessages,
+            output,
+            usage,
+            latencyMs: Date.now() - startedAt,
+            properties: {
+              request_id: requestId,
+              streaming: true,
+              has_garmin_context: Boolean(garminContextSummary),
+            },
+          })
           controller.close()
         } catch (streamError) {
           logger.error("Chat stream error:", streamError)
-          void captureAIGeneration({
+          await captureAIGeneration({
             traceName: "chat",
             distinctId: parsedUserId,
             model: OPENAI_MODEL,

--- a/v0/app/api/chat/route.ts
+++ b/v0/app/api/chat/route.ts
@@ -6,6 +6,7 @@ import { buildGarminContext, buildGarminContextSummary } from "@/lib/enhanced-ai
 import { logger } from "@/lib/logger"
 import { rateLimiter, securityConfig } from "@/lib/security.config"
 import { securityMonitor } from "@/lib/security.monitoring"
+import { captureAIGeneration } from "@/lib/ai-observability"
 
 export const runtime = "nodejs"
 export const dynamic = "force-dynamic"
@@ -63,6 +64,9 @@ function toChatMessage(input: { role?: unknown; content?: unknown }): ChatInputM
 }
 
 export async function POST(req: Request): Promise<Response> {
+  const requestId = `chat_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
+  const startedAt = Date.now()
+
   if (!process.env.OPENAI_API_KEY?.trim()) {
     return NextResponse.json({ error: "OpenAI API key not configured", fallback: true }, { status: 503 })
   }
@@ -140,15 +144,49 @@ export async function POST(req: Request): Promise<Response> {
     const transformed = new ReadableStream({
       async start(controller) {
         const encoder = new TextEncoder()
+        let output = ""
         try {
           for await (const text of textStream) {
             if (!text) continue
+            output += text
             const chunk = `0:${JSON.stringify({ textDelta: text })}\n`
             controller.enqueue(encoder.encode(chunk))
           }
+          void Promise.resolve((result as any).usage)
+            .then((usage) =>
+              captureAIGeneration({
+                traceName: "chat",
+                distinctId: parsedUserId,
+                model: OPENAI_MODEL,
+                input: apiMessages,
+                output,
+                usage,
+                latencyMs: Date.now() - startedAt,
+                properties: {
+                  request_id: requestId,
+                  streaming: true,
+                  has_garmin_context: Boolean(garminContextSummary),
+                },
+              })
+            )
+            .catch(() => {})
           controller.close()
         } catch (streamError) {
           logger.error("Chat stream error:", streamError)
+          void captureAIGeneration({
+            traceName: "chat",
+            distinctId: parsedUserId,
+            model: OPENAI_MODEL,
+            input: apiMessages,
+            output,
+            latencyMs: Date.now() - startedAt,
+            error: streamError,
+            properties: {
+              request_id: requestId,
+              streaming: true,
+              has_garmin_context: Boolean(garminContextSummary),
+            },
+          })
           const errorChunk = `0:${JSON.stringify({ textDelta: "\n\n[Error: Failed to complete response.]" })}\n`
           controller.enqueue(encoder.encode(errorChunk))
           controller.close()
@@ -205,4 +243,3 @@ export async function OPTIONS(req: Request): Promise<Response> {
     },
   })
 }
-

--- a/v0/app/api/generate-plan/route.ts
+++ b/v0/app/api/generate-plan/route.ts
@@ -19,6 +19,7 @@ import {
   enforcePlanSafety,
   computeMaxOutputTokens,
 } from '@/lib/plan/plan-core';
+import { captureAIGeneration } from '@/lib/ai-observability';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -39,6 +40,7 @@ function getClientIP(request: Request): string {
 
 export async function POST(req: Request) {
   const requestId = `plan_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+  const startedAt = Date.now();
 
   // Rate limiting check (10 requests per minute for AI routes)
   const clientIP = getClientIP(req);
@@ -87,10 +89,10 @@ export async function POST(req: Request) {
     const fallbackPlan = generateFallbackPlan(user, totalWeeks, body.planPreferences, body.challenge);
 
     let advancedMetrics: PersonalizationContext['advancedMetrics'] | undefined;
+    const resolvedUserId = body.userContext?.userId ?? body.userId;
+    const parsedUserId =
+      typeof resolvedUserId === 'string' ? parseInt(resolvedUserId, 10) : resolvedUserId;
     if (body.userContext?.userId || body.userId) {
-      const resolvedUserId = body.userContext?.userId ?? body.userId;
-      const parsedUserId =
-        typeof resolvedUserId === 'string' ? parseInt(resolvedUserId, 10) : resolvedUserId;
       if (typeof parsedUserId === 'number' && Number.isFinite(parsedUserId)) {
         try {
           const context = await PersonalizationContextBuilder.build(parsedUserId);
@@ -120,17 +122,37 @@ export async function POST(req: Request) {
       body.goals
     );
 
+    const modelName = 'gpt-4o';
+    const maxOutputTokens = computeMaxOutputTokens(totalWeeks, user.daysPerWeek);
+
     const result = await withSecureOpenAI(async () => {
       return generateObject({
-        model: openai('gpt-4o'),
+        model: openai(modelName),
         schema: PlanSchema,
         prompt,
         temperature: 0.7,
-        maxOutputTokens: computeMaxOutputTokens(totalWeeks, user.daysPerWeek),
+        maxOutputTokens,
       });
     });
 
     if (!result.success || !result.data) {
+      await captureAIGeneration({
+        traceName: 'generate-plan',
+        distinctId: typeof parsedUserId === 'number' ? parsedUserId : user.id,
+        model: modelName,
+        input: prompt,
+        latencyMs: Date.now() - startedAt,
+        error: result.error?.message || 'AI service unavailable',
+        properties: {
+          request_id: requestId,
+          streaming: false,
+          total_weeks: totalWeeks,
+          plan_type: body.planType,
+          target_distance: body.targetDistance,
+          max_output_tokens: maxOutputTokens,
+        },
+      });
+
       return NextResponse.json(
         {
           plan: fallbackPlan,
@@ -156,6 +178,24 @@ export async function POST(req: Request) {
         { status: 502 }
       );
     }
+
+    await captureAIGeneration({
+      traceName: 'generate-plan',
+      distinctId: typeof parsedUserId === 'number' ? parsedUserId : user.id,
+      model: modelName,
+      input: prompt,
+      output: generated.object,
+      usage: (result.data as any).usage,
+      latencyMs: Date.now() - startedAt,
+      properties: {
+        request_id: requestId,
+        streaming: false,
+        total_weeks: totalWeeks,
+        plan_type: body.planType,
+        target_distance: body.targetDistance,
+        max_output_tokens: maxOutputTokens,
+      },
+    });
 
     return NextResponse.json(
       {

--- a/v0/app/api/run-report/route.ts
+++ b/v0/app/api/run-report/route.ts
@@ -8,6 +8,7 @@ import { ENABLE_AUTO_PAUSE, ENABLE_PACE_CHART } from '@/lib/featureFlags'
 import { calculateGPSQualityScore, getGPSQualityLevel, type GPSAccuracyData } from '@/lib/gps-monitoring'
 import { logger } from '@/lib/logger'
 import { withApiSecurity, type ApiRequest } from '@/lib/security.middleware'
+import { captureAIGeneration } from '@/lib/ai-observability'
 
 const RUN_TYPES = ['easy', 'tempo', 'intervals', 'long', 'time-trial', 'hill', 'other'] as const
 type RunType = (typeof RUN_TYPES)[number]
@@ -1125,15 +1126,11 @@ const handler = async (req: ApiRequest) => {
     model: RUN_REPORT_MODEL,
   })
 
-  const aiResult = await withSecureOpenAI(async () => {
-    const { object } = await generateObject({
-      model: openai(RUN_REPORT_MODEL),
-      schema: InsightSchema,
-      prompt: [
-        {
-          role: 'system',
-          content:
-            `You are Run-Smart, an elite evidence-based running coach providing premium post-run analysis. Be supportive, specific, and practical. No medical diagnosis. If pain or dizziness is noted, advise stopping and consulting a professional.
+  const promptMessages = [
+    {
+      role: 'system' as const,
+      content:
+        `You are Run-Smart, an elite evidence-based running coach providing premium post-run analysis. Be supportive, specific, and practical. No medical diagnosis. If pain or dizziness is noted, advise stopping and consulting a professional.
 
 CORE FIELDS (always fill):
 - summary[0]: Headline with key stats (distance, duration, avg pace)
@@ -1162,29 +1159,35 @@ SCORING GUIDE:
 - 75-89: Good run with minor areas for improvement
 - 60-74: Decent but notable issues (erratic pacing, wrong effort level)
 - Below 60: Significant concerns (injury signals, major pacing issues)`,
-        },
-        {
-          role: 'user',
-          content: `Skill: run-insights-recovery\nInput:\n${JSON.stringify(
-            skillInput,
-            null,
-            2
-          )}\n${
-            paceStats
-              ? `\nPacing Analysis:\n- Was the pace consistent, fading (positive split), or negative split?\n- Average pace: ${formatPace(
-                  paceStats.avgPaceMinPerKm * 60
-                )}, pace range: ${formatPace(paceStats.minPaceMinPerKm * 60)}-${formatPace(
-                  paceStats.maxPaceMinPerKm * 60
-                )}\n- Pace variability: ${Math.round(
-                  paceStats.variabilityMinPerKm * 60
-                )}s (low = consistent, high = erratic)\n- Provide 1-2 sentence pacing assessment\n- If pacing was poor, suggest a specific improvement\n- Include pacingAnalysis (1-2 sentences), paceConsistency, and paceVariability (seconds per km as number)\n- Current paceConsistency suggestion: ${paceConsistency ?? 'unknown'}`
-              : '\nPacing Analysis: Pace data unavailable; omit pacingAnalysis, paceConsistency, paceVariability.'
-          }\nReturn JSON that matches the provided schema.`,
-        },
-      ],
+    },
+    {
+      role: 'user' as const,
+      content: `Skill: run-insights-recovery\nInput:\n${JSON.stringify(
+        skillInput,
+        null,
+        2
+      )}\n${
+        paceStats
+          ? `\nPacing Analysis:\n- Was the pace consistent, fading (positive split), or negative split?\n- Average pace: ${formatPace(
+              paceStats.avgPaceMinPerKm * 60
+            )}, pace range: ${formatPace(paceStats.minPaceMinPerKm * 60)}-${formatPace(
+              paceStats.maxPaceMinPerKm * 60
+            )}\n- Pace variability: ${Math.round(
+              paceStats.variabilityMinPerKm * 60
+            )}s (low = consistent, high = erratic)\n- Provide 1-2 sentence pacing assessment\n- If pacing was poor, suggest a specific improvement\n- Include pacingAnalysis (1-2 sentences), paceConsistency, and paceVariability (seconds per km as number)\n- Current paceConsistency suggestion: ${paceConsistency ?? 'unknown'}`
+          : '\nPacing Analysis: Pace data unavailable; omit pacingAnalysis, paceConsistency, paceVariability.'
+      }\nReturn JSON that matches the provided schema.`,
+    },
+  ]
+
+  const aiResult = await withSecureOpenAI(async () => {
+    const result = await generateObject({
+      model: openai(RUN_REPORT_MODEL),
+      schema: InsightSchema,
+      prompt: promptMessages,
     })
 
-    return object
+    return result
   }, fallbackInsight)
 
   if (!aiResult.success && aiResult.error) {
@@ -1192,9 +1195,25 @@ SCORING GUIDE:
     logError('run-report.ai', aiResult.error, { runId: normalized.runId })
   }
 
-  const report = normalizeInsight(aiResult.data ?? fallbackInsight, fallbackInsight)
+  const generation = aiResult.success ? (aiResult.data as any) : null
+  const report = normalizeInsight(generation?.object ?? aiResult.data ?? fallbackInsight, fallbackInsight)
   const reportWithGpsQuality = gpsQuality ? { ...report, gpsQuality } : report
   const source = aiResult.success ? ('ai' as const) : ('fallback' as const)
+
+  await captureAIGeneration({
+    traceName: 'run-report',
+    model: RUN_REPORT_MODEL,
+    input: promptMessages,
+    output: report,
+    usage: generation?.usage,
+    latencyMs: Date.now() - requestStartedAt,
+    error: aiResult.success ? undefined : aiResult.error,
+    properties: {
+      run_id: normalized.runId,
+      source,
+      streaming: false,
+    },
+  })
 
   logger.info('ai_insight_created', {
     run_id: report.runId,

--- a/v0/lib/adaptiveCoachingEngine.ts
+++ b/v0/lib/adaptiveCoachingEngine.ts
@@ -3,6 +3,7 @@ import { generateObject } from 'ai';
 import { z } from 'zod';
 import { CoachingProfile, CoachingFeedback } from './db';
 import { dbUtils } from '@/lib/dbUtils';
+import { captureAIGeneration } from '@/lib/ai-observability';
 
 // Context interfaces
 export interface UserContext {
@@ -100,6 +101,7 @@ export class AdaptiveCoachingEngine {
     context: UserContext,
     options?: { throwOnError?: boolean }
   ): Promise<CoachingResponse> {
+    const responseStartedAt = Date.now();
     try {
       const profile = (await dbUtils.getCoachingProfile(userId)) ?? undefined;
       const adaptedPrompt = await this.adaptPromptToProfile(query, profile, context);
@@ -119,6 +121,21 @@ export class AdaptiveCoachingEngine {
         maxOutputTokens: 800,
       });
 
+      await captureAIGeneration({
+        traceName: 'chat',
+        distinctId: userId,
+        model: modelName,
+        input: adaptedPrompt,
+        output: result.object,
+        usage: (result as any).usage,
+        latencyMs: Date.now() - responseStartedAt,
+        properties: {
+          interaction_id: interactionId,
+          adaptive_coaching: true,
+          streaming: false,
+        },
+      });
+
       const response: CoachingResponse = {
         response: result.object.response,
         confidence: result.object.confidence,
@@ -135,6 +152,21 @@ export class AdaptiveCoachingEngine {
       return response;
     } catch (error) {
       console.error('Error generating personalized response:', error);
+      void captureAIGeneration({
+        traceName: 'chat',
+        distinctId: userId,
+        model:
+          process.env.CHAT_COACHING_MODEL ||
+          process.env.CHAT_DEFAULT_MODEL ||
+          'gpt-4o',
+        input: { query, context },
+        latencyMs: Date.now() - responseStartedAt,
+        error,
+        properties: {
+          adaptive_coaching: true,
+          streaming: false,
+        },
+      });
 
       if (options?.throwOnError) {
         throw error;
@@ -162,17 +194,19 @@ export class AdaptiveCoachingEngine {
     userId: number,
     context: UserContext
   ): Promise<AdaptiveRecommendation[]> {
+    const recommendationStartedAt = Date.now();
+    let recommendationPrompt = '';
+    const modelName =
+      process.env.CHAT_COACHING_MODEL ||
+      process.env.CHAT_DEFAULT_MODEL ||
+      'gpt-4o';
+
     try {
       const profile = (await dbUtils.getCoachingProfile(userId)) ?? undefined;
       const patterns = await dbUtils.getBehaviorPatterns(userId);
       const recentFeedback = await dbUtils.getCoachingFeedback(userId, 10);
       
-      const recommendationPrompt = this.buildRecommendationPrompt(profile, patterns, recentFeedback, context);
-
-      const modelName =
-        process.env.CHAT_COACHING_MODEL ||
-        process.env.CHAT_DEFAULT_MODEL ||
-        'gpt-4o';
+      recommendationPrompt = this.buildRecommendationPrompt(profile, patterns, recentFeedback, context);
       
       const result = await generateObject({
         model: openai(modelName),
@@ -180,6 +214,20 @@ export class AdaptiveCoachingEngine {
         prompt: recommendationPrompt,
         temperature: 0.6,
         maxOutputTokens: 900,
+      });
+
+      await captureAIGeneration({
+        traceName: 'chat',
+        distinctId: userId,
+        model: modelName,
+        input: recommendationPrompt,
+        output: result.object,
+        usage: (result as any).usage,
+        latencyMs: Date.now() - recommendationStartedAt,
+        properties: {
+          adaptive_recommendations: true,
+          streaming: false,
+        },
       });
 
       return result.object.recommendations.map(rec => ({
@@ -194,6 +242,18 @@ export class AdaptiveCoachingEngine {
       }));
     } catch (error) {
       console.error('Error generating adaptive recommendations:', error);
+      void captureAIGeneration({
+        traceName: 'chat',
+        distinctId: userId,
+        model: modelName,
+        input: recommendationPrompt || { context },
+        latencyMs: Date.now() - recommendationStartedAt,
+        error,
+        properties: {
+          adaptive_recommendations: true,
+          streaming: false,
+        },
+      });
       return [];
     }
   }

--- a/v0/lib/ai-observability.test.ts
+++ b/v0/lib/ai-observability.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { aiObservabilityTestUtils, captureAIGeneration } from './ai-observability'
+
+describe('ai-observability', () => {
+  const originalEnv = { ...process.env }
+  const originalFetch = global.fetch
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    global.fetch = originalFetch
+  })
+
+  it('redacts contact details and data URLs before capture', () => {
+    const redacted = aiObservabilityTestUtils.redactTelemetryValue({
+      name: 'Nadav',
+      email: 'nadav@example.com',
+      phone: '+1 (555) 123-4567',
+      prompt: 'Email nadav@example.com with data:image/png;base64,abc123',
+    })
+
+    expect(redacted).toEqual({
+      name: '[redacted-name]',
+      email: '[redacted-email]',
+      phone: '[redacted-phone]',
+      prompt: 'Email [redacted-email] with [redacted-data-url]',
+    })
+  })
+
+  it('captures a PostHog $ai_generation event with trace metadata', async () => {
+    process.env.POSTHOG_API_KEY = 'phc_test'
+    process.env.POSTHOG_HOST = 'https://us.i.posthog.com'
+    vi.stubGlobal('window', undefined)
+    const fetchMock = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    global.fetch = fetchMock as typeof fetch
+
+    await captureAIGeneration({
+      traceName: 'generate-plan',
+      distinctId: 42,
+      model: 'gpt-4o',
+      input: [{ role: 'user', content: 'Build a plan' }],
+      output: { title: 'Plan' },
+      usage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      latencyMs: 1234,
+      properties: { request_id: 'req_1' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://us.i.posthog.com/capture/',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string)
+    expect(body.event).toBe('$ai_generation')
+    expect(body.api_key).toBe('phc_test')
+    expect(body.properties).toEqual(
+      expect.objectContaining({
+        distinct_id: '42',
+        $ai_provider: 'openai',
+        $ai_model: 'gpt-4o',
+        $ai_trace_name: 'generate-plan',
+        $ai_input_tokens: 10,
+        $ai_output_tokens: 20,
+        $ai_total_tokens: 30,
+        $ai_latency: 1234,
+        request_id: 'req_1',
+      })
+    )
+  })
+})

--- a/v0/lib/ai-observability.ts
+++ b/v0/lib/ai-observability.ts
@@ -1,0 +1,154 @@
+type AIUsage = {
+  promptTokens?: number
+  completionTokens?: number
+  totalTokens?: number
+  inputTokens?: number
+  outputTokens?: number
+}
+
+export type AIGenerationCaptureArgs = {
+  traceName: string
+  distinctId?: string | number | null
+  model: string
+  input: unknown
+  output?: unknown
+  usage?: AIUsage | null
+  latencyMs: number
+  error?: unknown
+  properties?: Record<string, unknown>
+}
+
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com"
+const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+const PHONE_PATTERN = /(?:\+?\d[\d\s().-]{7,}\d)/g
+const DATA_URL_PATTERN = /data:[^;,]+\/[^;,]+;base64,[A-Za-z0-9+/=]+/g
+const CONTACT_FIELD_KEYS = new Set(["name", "email", "phone"])
+const CAPTURE_TIMEOUT_MS = 1500
+
+function getPostHogConfig(): { apiKey: string; host: string } | null {
+  if (typeof window !== "undefined") return null
+
+  const apiKey = process.env.POSTHOG_API_KEY?.trim() || ""
+
+  if (!apiKey) return null
+
+  const host = (
+    process.env.POSTHOG_HOST?.trim() ||
+    process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() ||
+    DEFAULT_POSTHOG_HOST
+  ).replace(/\/$/, "")
+
+  return { apiKey, host }
+}
+
+function redactTelemetryValue(value: unknown, key?: string): unknown {
+  const normalizedKey = key?.toLowerCase()
+  if (normalizedKey && CONTACT_FIELD_KEYS.has(normalizedKey)) {
+    return `[redacted-${normalizedKey}]`
+  }
+
+  if (typeof value === "string") {
+    return value
+      .replace(DATA_URL_PATTERN, "[redacted-data-url]")
+      .replace(EMAIL_PATTERN, "[redacted-email]")
+      .replace(PHONE_PATTERN, "[redacted-phone]")
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactTelemetryValue(item))
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
+        entryKey,
+        redactTelemetryValue(entryValue, entryKey),
+      ])
+    )
+  }
+
+  return value
+}
+
+function usageNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function getInputTokens(usage?: AIUsage | null): number {
+  return usageNumber(usage?.promptTokens ?? usage?.inputTokens)
+}
+
+function getOutputTokens(usage?: AIUsage | null): number {
+  return usageNumber(usage?.completionTokens ?? usage?.outputTokens)
+}
+
+function getTotalTokens(usage?: AIUsage | null): number {
+  return usageNumber(usage?.totalTokens) || getInputTokens(usage) + getOutputTokens(usage)
+}
+
+function getHttpStatus(error?: unknown): number {
+  if (!error || typeof error !== "object") return 200
+  const err = error as {
+    statusCode?: unknown
+    status?: unknown
+    response?: { status?: unknown }
+  }
+  const status = err.statusCode ?? err.status ?? err.response?.status
+  return typeof status === "number" ? status : 500
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function captureAIGeneration(args: AIGenerationCaptureArgs): Promise<void> {
+  const config = getPostHogConfig()
+  if (!config) return
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), CAPTURE_TIMEOUT_MS)
+  const traceId = crypto.randomUUID()
+  const distinctId = args.distinctId !== undefined && args.distinctId !== null ? String(args.distinctId) : traceId
+  const outputChoices = args.output !== undefined ? [{ content: args.output }] : []
+
+  const properties = {
+    distinct_id: distinctId,
+    $ai_lib: "runsmart-vercel-ai-sdk-manual",
+    $ai_provider: "openai",
+    $ai_model: args.model,
+    $ai_model_parameters: {},
+    $ai_input: redactTelemetryValue(args.input),
+    $ai_output_choices: redactTelemetryValue(outputChoices),
+    $ai_http_status: getHttpStatus(args.error),
+    $ai_input_tokens: getInputTokens(args.usage),
+    $ai_output_tokens: getOutputTokens(args.usage),
+    $ai_total_tokens: getTotalTokens(args.usage),
+    $ai_latency: args.latencyMs,
+    $ai_trace_id: traceId,
+    $ai_trace_name: args.traceName,
+    $ai_is_error: Boolean(args.error),
+    ...(args.error ? { $ai_error: errorMessage(args.error) } : {}),
+    ...args.properties,
+  }
+
+  try {
+    await fetch(`${config.host}/capture/`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        api_key: config.apiKey,
+        event: "$ai_generation",
+        properties,
+      }),
+    })
+  } catch {
+    // Telemetry must never break AI product paths.
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+export const aiObservabilityTestUtils = {
+  redactTelemetryValue,
+}

--- a/v0/lib/chatDriver.ts
+++ b/v0/lib/chatDriver.ts
@@ -2,6 +2,7 @@ import { generateText, streamText } from 'ai'
 import type { CoreMessage } from 'ai'
 import { openai } from '@ai-sdk/openai'
 import { dbUtils } from '@/lib/dbUtils'
+import { captureAIGeneration } from '@/lib/ai-observability'
 
 // ============================================================================
 // TYPES AND INTERFACES
@@ -24,6 +25,7 @@ export interface ChatRequest {
    */
   maxOutputTokens?: number
   model?: string
+  traceName?: string
 }
 
 export interface ChatResponse {
@@ -409,6 +411,9 @@ export class ChatDriver {
 
     const requestId = generateRequestId()
     const startTime = Date.now()
+    const traceName = request.traceName || 'chat'
+    let aiMessages: CoreMessage[] = []
+    const aiModelName = request.model || config.defaultModel
 
     console.log(`[chat:ask] requestId=${requestId} Starting chat request`)
     console.log(
@@ -444,6 +449,7 @@ export class ChatDriver {
       }
 
       const { messages, metrics } = await this.preparePayload(request, requestId)
+      aiMessages = messages
 
       const monthKey = getUserMonthKey(userKey)
       const alreadyUsed = this.getTokensUsed(monthKey)
@@ -461,7 +467,7 @@ export class ChatDriver {
 
       this.addTokens(monthKey, metrics.tokensIn)
 
-      const modelName = request.model || config.defaultModel
+      const modelName = aiModelName
       const maxOutputTokens = request.maxOutputTokens ?? request.maxTokens ?? config.maxOutputTokens
       const model = openai(modelName)
 
@@ -487,6 +493,28 @@ export class ChatDriver {
           })
           .catch(() => {})
 
+        void Promise.allSettled([
+          Promise.resolve((result as any).text ?? ''),
+          Promise.resolve((result as any).usage),
+        ]).then(([textResult, usageResult]) => {
+          const output = textResult.status === 'fulfilled' ? textResult.value : ''
+          const usage = usageResult.status === 'fulfilled' ? usageResult.value : undefined
+          return captureAIGeneration({
+            traceName,
+            distinctId: request.userId,
+            model: modelName,
+            input: messages,
+            output,
+            usage,
+            latencyMs: Date.now() - startTime,
+            properties: {
+              request_id: requestId,
+              streaming: true,
+              current_phase: request.currentPhase,
+            },
+          })
+        })
+
         const response = (result as any).toDataStreamResponse?.() ?? (result as any).toTextStreamResponse?.()
         return { success: true, stream: response?.body }
       }
@@ -510,6 +538,21 @@ export class ChatDriver {
 
       this.addTokens(monthKey, Math.max(0, promptTokens - metrics.tokensIn) + completionTokens)
 
+      await captureAIGeneration({
+        traceName,
+        distinctId: request.userId,
+        model: modelName,
+        input: messages,
+        output: (result as any).text ?? '',
+        usage,
+        latencyMs: duration,
+        properties: {
+          request_id: requestId,
+          streaming: false,
+          current_phase: request.currentPhase,
+        },
+      })
+
       return {
         success: true,
         data: {
@@ -522,6 +565,19 @@ export class ChatDriver {
         },
       }
     } catch (error) {
+      await captureAIGeneration({
+        traceName,
+        distinctId: request.userId,
+        model: aiModelName,
+        input: aiMessages.length > 0 ? aiMessages : request.messages,
+        latencyMs: Date.now() - startTime,
+        error,
+        properties: {
+          request_id: requestId,
+          streaming: Boolean(request.streaming),
+          current_phase: request.currentPhase,
+        },
+      })
       return { success: false, error: mapAiError(error, requestId) }
     }
   }

--- a/v0/lib/chatDriver.ts
+++ b/v0/lib/chatDriver.ts
@@ -480,40 +480,36 @@ export class ChatDriver {
             messages,
             maxOutputTokens,
             abortSignal: controller.signal,
+            // Runs as part of stream consumption, so the AI SDK keeps the
+            // response stream open until this resolves — unlike a bare
+            // fire-and-forget call, it can't be dropped by an early
+            // serverless function teardown once bytes are flushed.
+            onFinish: async ({ text, totalUsage }) => {
+              const promptTokens =
+                typeof totalUsage?.inputTokens === 'number' ? totalUsage.inputTokens : metrics.tokensIn
+              const completionTokens =
+                typeof totalUsage?.outputTokens === 'number' ? totalUsage.outputTokens : 0
+              this.addTokens(monthKey, Math.max(0, promptTokens - metrics.tokensIn) + completionTokens)
+
+              await captureAIGeneration({
+                traceName,
+                distinctId: request.userId,
+                model: modelName,
+                input: messages,
+                output: text,
+                usage: totalUsage,
+                latencyMs: Date.now() - startTime,
+                properties: {
+                  request_id: requestId,
+                  streaming: true,
+                  current_phase: request.currentPhase,
+                },
+              })
+            },
           }),
           config.timeoutMs,
           () => controller.abort()
         )
-
-        void Promise.resolve((result as any).usage)
-          .then((usage: any) => {
-            const promptTokens = typeof usage?.promptTokens === 'number' ? usage.promptTokens : metrics.tokensIn
-            const completionTokens = typeof usage?.completionTokens === 'number' ? usage.completionTokens : 0
-            this.addTokens(monthKey, Math.max(0, promptTokens - metrics.tokensIn) + completionTokens)
-          })
-          .catch(() => {})
-
-        void Promise.allSettled([
-          Promise.resolve((result as any).text ?? ''),
-          Promise.resolve((result as any).usage),
-        ]).then(([textResult, usageResult]) => {
-          const output = textResult.status === 'fulfilled' ? textResult.value : ''
-          const usage = usageResult.status === 'fulfilled' ? usageResult.value : undefined
-          return captureAIGeneration({
-            traceName,
-            distinctId: request.userId,
-            model: modelName,
-            input: messages,
-            output,
-            usage,
-            latencyMs: Date.now() - startTime,
-            properties: {
-              request_id: requestId,
-              streaming: true,
-              current_phase: request.currentPhase,
-            },
-          })
-        })
 
         const response = (result as any).toDataStreamResponse?.() ?? (result as any).toTextStreamResponse?.()
         return { success: true, stream: response?.body }

--- a/v0/lib/server/garmin-insights-service.ts
+++ b/v0/lib/server/garmin-insights-service.ts
@@ -14,6 +14,7 @@ import {
   type WeeklyInsightInput,
 } from "@/lib/garminInsightBuilder"
 import { logger } from "@/lib/logger"
+import { captureAIGeneration } from "@/lib/ai-observability"
 import { getGarminOAuthState } from "@/lib/server/garmin-oauth-store"
 import { createAdminClient } from "@/lib/supabase/admin"
 
@@ -428,14 +429,32 @@ export async function generateInsightForUser(
     }
   }
 
+  const startedAt = Date.now()
+  const messages = [
+    { role: "system" as const, content: prompts.systemPrompt },
+    { role: "user" as const, content: enrichedUserPrompt },
+  ]
   const result = await generateText({
     model: openai(DEFAULT_MODEL),
-    messages: [
-      { role: "system", content: prompts.systemPrompt },
-      { role: "user", content: enrichedUserPrompt },
-    ],
+    messages,
     temperature: 0.35,
     maxOutputTokens: 280,
+  })
+
+  await captureAIGeneration({
+    traceName: "garmin-insights",
+    distinctId: request.userId,
+    model: DEFAULT_MODEL,
+    input: messages,
+    output: result.text,
+    usage: (result as any).usage,
+    latencyMs: Date.now() - startedAt,
+    properties: {
+      insight_type: request.insightType,
+      activity_id: request.activityId,
+      streaming: false,
+      persisted_insight: true,
+    },
   })
 
   return {

--- a/v0/lib/server/posthog.ts
+++ b/v0/lib/server/posthog.ts
@@ -13,7 +13,11 @@ function getPosthogConfig(): { apiKey: string; host: string } | null {
 
   if (!apiKey) return null
 
-  const host = (process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() || DEFAULT_POSTHOG_HOST).replace(/\/$/, "")
+  const host = (
+    process.env.POSTHOG_HOST?.trim() ||
+    process.env.NEXT_PUBLIC_POSTHOG_HOST?.trim() ||
+    DEFAULT_POSTHOG_HOST
+  ).replace(/\/$/, "")
   return { apiKey, host }
 }
 


### PR DESCRIPTION
## Summary
- add server-safe PostHog `` capture helper for RunSmart AI calls
- instrument chat, adaptive coaching, Garmin insights, plan generation, run reports, AI activity extraction, and the worker AI activity job
- document server-side `POSTHOG_API_KEY` / `POSTHOG_HOST` env vars without adding dependencies or secrets

## Validation
- `npm run test -- lib/ai-observability.test.ts __tests__/chatDriver.test.ts app/api/generate-plan/route.test.ts app/api/ai/garmin-insights/route.test.ts app/api/ai-activity/route.test.ts --run`
- `npm run type-check`
- `npx eslint lib/ai-observability.ts lib/ai-observability.test.ts`
- `npm run build`
- `git diff --check`

## Notes
- Uses manual PostHog `/capture/` instead of `@posthog/ai` to avoid adding dependencies.
- Worker package build remains blocked by pre-existing type issues in `src/health.ts` and missing `../../shared/types/jobs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broader AI request tracking across chat, reports, plans, insights, and coaching flows for better monitoring and troubleshooting.

* **Bug Fixes**
  * Improved handling of AI failures and fallback paths so requests remain responsive.
  * Added privacy-safe redaction for sensitive text before telemetry is sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->