### PR TITLE
Add Garmin First Aha activation flow after connect

### DIFF
--- a/docs/superpowers/plans/2026-07-01-garmin-first-aha.md
+++ b/docs/superpowers/plans/2026-07-01-garmin-first-aha.md
@@ -1,0 +1,605 @@
+# Garmin First Aha First Build Plan
+
+Date: 2026-07-01
+Repo: RunSmart web
+Mode: Builder
+Status: Planned, not implemented
+
+## Objective
+
+Build the first Garmin-connected aha moment for RunSmart: after a user connects Garmin, RunSmart should generate a clear personal running profile, a safe 14-day adaptive starter block, and one recommended beginner-friendly challenge.
+
+## Recommendation
+
+The first build should be Garmin First Aha, but it should not be a standalone insight card. It should be a complete activation moment:
+
+1. "Here is what your Garmin history says about you."
+2. "Here is the safest next 14 days."
+3. "Here is the challenge that best fits your current pattern."
+
+This validates the research recommendation. Runcaster shows that a Garmin-trained AI coach becomes compelling when it immediately turns history into a near-term plan. Hashiri.AI shows the value of deep activity understanding, but RunSmart should avoid overwhelming everyday runners with dense analysis. Never Done shows that challenges can improve motivation, but the challenge should be personalized by Garmin history rather than generic.
+
+## Success Criteria
+
+- A first-time Garmin-connected user lands on a dedicated post-connection experience instead of being dropped into a generic profile screen.
+- The page can generate a personal running profile from recent Garmin data.
+- The page recommends a safe 14-day starter block using recent consistency, load, intensity, and recovery signals when available.
+- The page recommends exactly one challenge, with a short explanation.
+- The user can accept the plan, start the challenge, or skip without being trapped.
+- The output is transparent about missing Garmin data and does not overstate wellness signals.
+- The implementation reuses existing Garmin, plan, readiness, ACWR, challenge, and AI insight services where possible.
+
+## Non-Goals
+
+- Do not build Garmin workout push in this first version.
+- Do not build a coach dashboard.
+- Do not build a full 12-week adaptive coach flow.
+- Do not require sleep, HRV, Body Battery, or stress data for the experience to work.
+- Do not silently replace an existing active plan.
+- Do not make medical, diagnostic, or injury-prevention claims.
+
+## Target User
+
+Everyday Garmin runner who has just connected Garmin and wants to know:
+
+- What kind of runner am I right now?
+- Am I training safely?
+- What should I do next?
+- How do I get moving without overthinking?
+
+## First Five-Minute UX
+
+### Entry Point
+
+Current likely entry point:
+
+- `v0/app/garmin/callback/page.tsx`
+
+Today the callback completes Garmin auth, stores the local device, tracks `garmin_callback_completed`, and redirects to `/?screen=profile`.
+
+First build change:
+
+- First successful Garmin connection should redirect to a new Garmin First Aha route or screen.
+- Returning reconnects can continue to profile unless the user explicitly opens the aha experience.
+
+Recommended route:
+
+- `v0/app/garmin/first-aha/page.tsx`
+
+### Screen Structure
+
+The screen should feel like a coach reviewing the user's actual data, not a dashboard.
+
+1. Loading state
+   - "Reading your recent Garmin runs"
+   - Show steps for activities, consistency, recovery, and plan draft.
+
+2. Running profile
+   - Runner type: examples include "building consistency", "returning runner", "base-building runner", "fitness runner", "race-focused runner".
+   - Recent consistency: runs per week and recent gap pattern.
+   - Intensity pattern: easy/moderate/hard distribution when HR or pace data exists.
+   - Load pattern: recent volume, longest run, and ACWR status when available.
+   - Recovery context: sleep, HRV, resting HR, stress, Body Battery only if available.
+
+3. Safety read
+   - One plain-language sentence about the main guardrail.
+   - Examples:
+     - "Your recent volume looks stable, so the next two weeks can build gently."
+     - "Your last week jumped quickly, so the plan starts with a lighter reset."
+     - "You have enough run history for a plan, but not enough wellness data for recovery-based adjustments yet."
+
+4. 14-day starter block
+   - 3 to 5 planned sessions per week depending on current pattern.
+   - Each session has day, type, duration or distance, intensity, and purpose.
+   - Include at least one rest or recovery day.
+   - Prefer easy-run discipline over aggressive progression.
+
+5. Recommended challenge
+   - One challenge recommendation, not a grid.
+   - Options should map to existing or near-term challenge templates:
+     - Start running / consistency
+     - Easy-run discipline
+     - Return to running
+     - First consistent month
+     - Build base safely
+
+6. Actions
+   - Accept plan
+   - Start challenge
+   - Adjust goal
+   - Skip for now
+
+## Product Output Contract
+
+Create a server-side result shape that the UI can render without reinterpreting raw Garmin data.
+
+```ts
+type GarminFirstAhaResult = {
+  status: "ready" | "partial" | "insufficient_data" | "error"
+  generatedAt: string
+  dataWindow: {
+    activitiesDays: number
+    wellnessDays?: number
+  }
+  profile: {
+    runnerType: string
+    headline: string
+    summaryBullets: string[]
+    confidence: "high" | "medium" | "low"
+  }
+  signals: {
+    consistency: {
+      runsLast14Days: number
+      runsLast28Days: number
+      weeklyPatternLabel: string
+    }
+    load: {
+      weeklyDistanceTrend?: string
+      acwrLabel?: "low" | "stable" | "elevated" | "unknown"
+      longestRunLabel?: string
+    }
+    intensity: {
+      label: string
+      easyShare?: number
+      hardShare?: number
+      source: "heart_rate" | "pace" | "mixed" | "insufficient"
+    }
+    recovery?: {
+      readinessLabel: string
+      availableSignals: string[]
+      missingSignals: string[]
+    }
+  }
+  guardrails: {
+    level: "green" | "yellow" | "red"
+    message: string
+    reasons: string[]
+  }
+  starterPlan: {
+    title: string
+    rationale: string
+    days: Array<{
+      date: string
+      type: "easy_run" | "long_run" | "recovery" | "rest" | "strength" | "walk_run"
+      label: string
+      target?: string
+      intensity: "easy" | "moderate" | "hard" | "rest"
+      purpose: string
+    }>
+  }
+  recommendedChallenge: {
+    id: string
+    title: string
+    reason: string
+    fitScoreLabel: string
+  }
+  disclaimers: string[]
+}
+```
+
+## Existing Repo Surfaces To Reuse
+
+### Garmin Data
+
+- `v0/lib/garmin/datasets.ts`
+  - Garmin dataset catalog already includes activities, activity details, sleep, stress, HRV, user metrics, and other wellness keys.
+
+- `v0/lib/integrations/garmin/importGarminActivity.ts`
+  - Imports Garmin activities into canonical `runs`.
+
+- `v0/lib/integrations/garmin/mapGarminActivityToRun.ts`
+  - Identifies run-like Garmin activities and maps them into RunSmart run rows.
+
+- `v0/app/api/devices/garmin/backfill/route.ts`
+  - Existing path for 90-day activity and daily backfill.
+
+### Readiness And Load
+
+- `v0/lib/garminReadinessComputer.ts`
+  - Computes readiness from HRV, sleep, resting HR, stress, and optional wellness signals.
+
+- `v0/lib/garminAcwr.ts`
+  - Computes ACWR, monotony, strain, weekly volume, and elevated load flags.
+
+### AI Insights
+
+- `v0/lib/server/garmin-insights-service.ts`
+  - Existing AI insight service supports daily, weekly, and post-run insights.
+
+- `v0/lib/garminInsightBuilder.ts`
+  - Existing prompt and summary builder for Garmin daily, weekly, and post-run context.
+
+- `v0/app/api/ai/garmin-insights/route.ts`
+  - Existing API route for streaming and fetching Garmin insights.
+
+### Plan Generation
+
+- `v0/lib/planGenerator.ts`
+  - Existing plan generator supports configurable `totalWeeks`; fallback already has 2-week behavior for `rookie_challenge`.
+
+- `v0/app/api/generate-plan/route.ts`
+  - Existing plan generation route accepts preferences, training history, and goals.
+
+- `v0/lib/planAdaptationEngine.ts`
+  - Existing assessment logic for recent runs, goals, performance, and recovery.
+
+### Challenges
+
+- `v0/lib/challengeTemplates.ts`
+  - Existing challenge templates include start-running style templates.
+
+- `v0/lib/challengeEngine.ts`
+  - Existing client-side challenge start and active challenge logic.
+
+- `v0/app/api/challenges/route.ts`
+  - Existing server challenge list and join route.
+
+## Proposed Build Stories
+
+### Story 1: First Aha Server Endpoint
+
+Add a server endpoint that returns the normalized Garmin First Aha result.
+
+Suggested file:
+
+- `v0/app/api/garmin/first-aha/route.ts`
+
+Responsibilities:
+
+- Authenticate current user.
+- Load recent Garmin activities and canonical runs.
+- Load wellness/readiness data if available.
+- Compute consistency, load, intensity, and readiness labels.
+- Generate a 14-day starter block.
+- Select one recommended challenge.
+- Return a structured result with partial-data handling.
+
+Implementation preference:
+
+- Start deterministic first.
+- Use AI only for final wording once the data contract is stable.
+- Keep plan safety logic rule-based so guardrails are testable.
+
+### Story 2: First Aha Domain Service
+
+Create a small service so the API route stays thin.
+
+Suggested file:
+
+- `v0/lib/server/garmin-first-aha-service.ts`
+
+Responsibilities:
+
+- Fetch and normalize inputs.
+- Call or reuse readiness and ACWR helpers.
+- Build the `GarminFirstAhaResult`.
+- Own partial-data behavior.
+
+Suggested helper modules if needed:
+
+- `v0/lib/garminFirstAhaTypes.ts`
+- `v0/lib/garminFirstAhaPlan.ts`
+- `v0/lib/garminFirstAhaChallenge.ts`
+
+Keep the first implementation compact. Split helpers only when the service becomes hard to read.
+
+### Story 3: Post-Callback Redirect
+
+Update Garmin callback routing so first successful connection lands on the aha page.
+
+Suggested file:
+
+- `v0/app/garmin/callback/page.tsx`
+
+Behavior:
+
+- If Garmin connection just completed and the user has not seen Garmin First Aha, redirect to `/garmin/first-aha`.
+- If they have already seen it, keep the existing profile redirect.
+
+Open question for implementation:
+
+- Whether "seen" should initially be local storage only, or persisted to the user profile/preferences table. For v1, local storage is acceptable if no obvious server preference storage already exists.
+
+### Story 4: First Aha UI
+
+Add a dedicated page that renders the result and lets the user act.
+
+Suggested files:
+
+- `v0/app/garmin/first-aha/page.tsx`
+- `v0/components/garmin-first-aha-screen.tsx`
+
+UI states:
+
+- Loading
+- Ready
+- Partial data
+- Insufficient data
+- Error with retry
+
+Primary actions:
+
+- Accept 14-day plan
+- Start recommended challenge
+- Adjust goal
+- Skip for now
+
+Important UX rule:
+
+- Do not show a dense dashboard. Show a short coach-style review that explains the next step.
+
+### Story 5: Accept Plan And Start Challenge
+
+Wire actions to existing plan and challenge infrastructure.
+
+Plan options:
+
+- Preferred: convert the `starterPlan.days` into the existing plan shape and save through the same path used by onboarding or plan generation.
+- Fallback: call `v0/app/api/generate-plan/route.ts` with a 2-week goal preference and include the First Aha summary as context, if the route already supports this cleanly.
+
+Challenge options:
+
+- Use `v0/app/api/challenges/route.ts` for server challenge join if authenticated.
+- Use `v0/lib/challengeEngine.ts` only where the existing app flow expects client-side challenge state.
+
+Do not silently overwrite:
+
+- If an active plan exists, show "Review and replace" instead of immediate accept.
+- If an active challenge exists, show "Keep current challenge" and "Switch challenge".
+
+## Aha Logic
+
+### Runner Type Rules
+
+Use simple transparent labels:
+
+- `new_or_low_data_runner`
+  - Fewer than 3 runs in 28 days.
+- `building_consistency`
+  - 3 to 7 runs in 28 days, irregular spacing.
+- `consistent_base_builder`
+  - 8+ runs in 28 days, mostly easy or moderate.
+- `overreaching_risk`
+  - Recent volume spike, too many hard runs, or poor recovery signal.
+- `race_focused`
+  - Recent structured workouts, long runs, or high weekly frequency.
+
+Render user-facing labels, not internal ids.
+
+### Guardrail Rules
+
+Start with conservative heuristics:
+
+- Yellow if weekly volume increased more than roughly 25-35 percent.
+- Yellow if hard-run share is high and recovery signals are weak or missing.
+- Yellow if recent longest run is far above normal weekly pattern.
+- Red only for obvious "do less now" cases, such as severe load spike plus poor recovery signals.
+- Green when volume is stable, consistency is adequate, and recovery is not concerning.
+
+Use existing `garminAcwr` output where available instead of inventing a second load model.
+
+### 14-Day Plan Rules
+
+Plan should be based on recent behavior:
+
+- If 0 to 1 runs per week recently: 2 to 3 walk/run or easy sessions per week.
+- If 2 to 3 runs per week: maintain frequency, improve spacing, mostly easy.
+- If 4+ runs per week: keep frequency stable, reduce intensity if guardrails are yellow.
+- If load risk is elevated: reduce volume and add recovery.
+- If wellness data is missing: do not punish the user, mark recovery confidence as lower.
+
+Default progression:
+
+- Week 1 stabilizes.
+- Week 2 builds gently only if guardrails are green.
+
+### Challenge Selection Rules
+
+Recommended challenge should reinforce the safest next behavior:
+
+- Low frequency: `start-running` or "Run 3x/week".
+- Irregular spacing: "First consistent month".
+- Too much intensity: "Easy-run discipline".
+- Return after gap: "Return to running".
+- Stable base: "Build base safely".
+
+If the exact challenge template does not exist yet, the first implementation can map to the closest existing template and label future templates as backlog.
+
+## Analytics
+
+Track the activation funnel:
+
+- `garmin_first_aha_viewed`
+- `garmin_first_aha_generated`
+- `garmin_first_aha_partial_data`
+- `garmin_first_aha_plan_accepted`
+- `garmin_first_aha_challenge_started`
+- `garmin_first_aha_skipped`
+- `garmin_first_aha_error`
+
+Useful properties:
+
+- `activity_count_28d`
+- `has_wellness_data`
+- `guardrail_level`
+- `runner_type`
+- `recommended_challenge_id`
+- `plan_days_count`
+
+Primary metric:
+
+- Percent of newly connected Garmin users who accept a plan or start a challenge within the first session.
+
+Secondary metrics:
+
+- First post-connection run logged or synced within 7 days.
+- Return visit within 7 days.
+- Challenge completion.
+- Plan adherence in first 14 days.
+
+## Validation Plan
+
+### Unit Tests
+
+Add tests for deterministic service logic:
+
+- Insufficient data returns a useful partial result.
+- Low-frequency runner receives a conservative plan.
+- Elevated load produces yellow or red guardrails.
+- Missing wellness data lowers confidence without blocking the flow.
+- Challenge recommendation maps to the correct pattern.
+
+Likely test targets:
+
+- `garmin-first-aha-service`
+- `garminFirstAhaPlan`
+- `garminFirstAhaChallenge`
+
+### API Tests
+
+Verify:
+
+- Unauthenticated users are rejected.
+- Authenticated users receive a stable response shape.
+- Empty Garmin history returns `insufficient_data`, not a 500.
+- Partial wellness data does not fail the endpoint.
+
+### Manual QA
+
+Use seeded or mocked states:
+
+- No Garmin runs.
+- 2 recent easy runs.
+- 8 consistent runs.
+- Big recent volume spike.
+- Runs available, wellness unavailable.
+- Runs and readiness data available.
+- Existing active plan.
+- Existing active challenge.
+
+### UX QA
+
+Check desktop and mobile:
+
+- Loading state does not jump.
+- Summary text fits on mobile.
+- Actions are visible without scrolling through a long dashboard.
+- Partial-data state still gives a next step.
+
+## Risks And Mitigations
+
+### Risk: Garmin Backfill Is Not Finished When The Page Loads
+
+Mitigation:
+
+- Page should poll or retry while backfill is pending if an existing sync status exists.
+- If no status exists, show a partial result and a "Refresh after sync" action.
+
+### Risk: AI Makes The Output Feel Generic
+
+Mitigation:
+
+- Compute facts deterministically.
+- Let AI only phrase the profile and rationale.
+- Include specific numbers from the user's history in the prompt.
+
+### Risk: Plan Acceptance Conflicts With Existing Plans
+
+Mitigation:
+
+- Detect active plan before accepting.
+- Require explicit review before replacement.
+
+### Risk: Wellness Signals Are Not Available For Many Users
+
+Mitigation:
+
+- Make the experience valuable with activities alone.
+- Treat recovery as an optional confidence layer.
+
+### Risk: Too Much Product In One Screen
+
+Mitigation:
+
+- Show only one profile, one guardrail, one plan, and one challenge.
+- Move advanced analysis into later post-run or deep analysis tools.
+
+## Roadmap Split
+
+### Immediate v1
+
+- First Aha endpoint.
+- First Aha page.
+- Deterministic profile, guardrails, 14-day starter block, and challenge recommendation.
+- Post-Garmin callback redirect.
+- Accept plan and start challenge actions if existing APIs make this straightforward.
+
+### v1.1
+
+- Persist "Garmin First Aha seen".
+- Improve plan acceptance flow for users with active plans.
+- Add better sync-pending state.
+- Add post-run check-in entry point from the First Aha page.
+
+### v1.5
+
+- Add richer challenge templates:
+  - Easy-run discipline
+  - Return to running
+  - First consistent month
+  - Build base safely
+- Add adaptive plan revision after each synced Garmin run.
+- Add readiness-based daily plan adjustment.
+
+### Later
+
+- Garmin workout push.
+- Deep freemium analysis tools.
+- Coach or accountability partner dashboard.
+- Broader health intelligence.
+
+## Recommended Implementation Order
+
+1. Build `garmin-first-aha-service` with deterministic fixtures and tests.
+2. Add `GET /api/garmin/first-aha`.
+3. Add `/garmin/first-aha` page with loading, ready, partial, and insufficient states.
+4. Wire Garmin callback redirect for first successful connection.
+5. Wire accept plan and start challenge actions.
+
+## Definition Of Done
+
+- New Garmin-connected users see Garmin First Aha after successful connection.
+- The page returns a useful result with activities only.
+- The page gets better when wellness/readiness data exists.
+- The 14-day plan is conservative, readable, and explicitly tied to recent Garmin history.
+- One challenge is recommended with a clear reason.
+- Users can accept, start, adjust, or skip.
+- Unit tests cover the profile, guardrail, plan, and challenge selection rules.
+- Existing Garmin callback and profile flows still work.
+- No unrelated Garmin application assets are modified.
+
+## Suggested Next Codex Implementation Prompt
+
+```text
+Implement the Garmin First Aha v1 from docs/superpowers/plans/2026-07-01-garmin-first-aha.md.
+
+Scope:
+- Add a deterministic Garmin First Aha server service.
+- Add GET /api/garmin/first-aha.
+- Add /garmin/first-aha page and component.
+- Redirect first successful Garmin callback to /garmin/first-aha.
+- Reuse existing Garmin activity, readiness, ACWR, plan, and challenge code where possible.
+
+Constraints:
+- Do not build Garmin workout push.
+- Do not silently replace active plans.
+- Do not require wellness data.
+- Keep AI optional or limited to wording; deterministic safety logic must be testable.
+- Do not touch unrelated Garmin application docs/assets.
+
+Validation:
+- Add targeted tests for First Aha service logic.
+- Run the relevant test command for touched files.
+- Run lint/typecheck if documented for this repo.
+- Manually verify the first-connect route behavior.
+```

--- a/v0/app/api/garmin/first-aha/route.test.ts
+++ b/v0/app/api/garmin/first-aha/route.test.ts
@@ -79,6 +79,36 @@ describe('GET /api/garmin/first-aha', () => {
     expect(body.recommendedChallenge.id).toBe('start-running')
   })
 
+  it('rejects a mismatched authUserId', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
+    getGarminOAuthStateMock.mockResolvedValueOnce({ authUserId: 'someone-else', profileId: 10 })
+
+    const { GET } = await loadRoute()
+    const res = await GET(
+      new Request('http://localhost/api/garmin/first-aha?userId=1', {
+        headers: { 'x-user-id': '1' },
+      })
+    )
+
+    expect(res.status).toBe(403)
+    expect(generateGarminFirstAhaMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the connection has no owner recorded, instead of allowing any authenticated user through', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
+    getGarminOAuthStateMock.mockResolvedValueOnce({ authUserId: null, profileId: 10 })
+
+    const { GET } = await loadRoute()
+    const res = await GET(
+      new Request('http://localhost/api/garmin/first-aha?userId=1', {
+        headers: { 'x-user-id': '1' },
+      })
+    )
+
+    expect(res.status).toBe(403)
+    expect(generateGarminFirstAhaMock).not.toHaveBeenCalled()
+  })
+
   it('returns insufficient_data without 500 for empty history', async () => {
     getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
     getGarminOAuthStateMock.mockResolvedValueOnce({ authUserId: 'auth-1', profileId: 10 })

--- a/v0/app/api/garmin/first-aha/route.test.ts
+++ b/v0/app/api/garmin/first-aha/route.test.ts
@@ -14,9 +14,13 @@ vi.mock('@/lib/server/garmin-oauth-store', () => ({
   getGarminOAuthState: getGarminOAuthStateMock,
 }))
 
-vi.mock('@/lib/server/garmin-first-aha-service', () => ({
-  generateGarminFirstAha: generateGarminFirstAhaMock,
-}))
+vi.mock('@/lib/server/garmin-first-aha-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/server/garmin-first-aha-service')>()
+  return {
+    ...actual,
+    generateGarminFirstAha: generateGarminFirstAhaMock,
+  }
+})
 
 async function loadRoute() {
   return import('./route')
@@ -106,6 +110,24 @@ describe('GET /api/garmin/first-aha', () => {
     )
 
     expect(res.status).toBe(403)
+    expect(generateGarminFirstAhaMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the rich unavailable fallback (not a bare error) when no Garmin connection exists', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
+    getGarminOAuthStateMock.mockResolvedValueOnce(null)
+
+    const { GET } = await loadRoute()
+    const res = await GET(
+      new Request('http://localhost/api/garmin/first-aha?userId=1', {
+        headers: { 'x-user-id': '1' },
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(404)
+    expect(body.status).toBe('error')
+    expect(body.profile.headline).toBeTruthy()
     expect(generateGarminFirstAhaMock).not.toHaveBeenCalled()
   })
 

--- a/v0/app/api/garmin/first-aha/route.test.ts
+++ b/v0/app/api/garmin/first-aha/route.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getUserMock = vi.hoisted(() => vi.fn())
+const getGarminOAuthStateMock = vi.hoisted(() => vi.fn())
+const generateGarminFirstAhaMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: getUserMock },
+  })),
+}))
+
+vi.mock('@/lib/server/garmin-oauth-store', () => ({
+  getGarminOAuthState: getGarminOAuthStateMock,
+}))
+
+vi.mock('@/lib/server/garmin-first-aha-service', () => ({
+  generateGarminFirstAha: generateGarminFirstAhaMock,
+}))
+
+async function loadRoute() {
+  return import('./route')
+}
+
+describe('GET /api/garmin/first-aha', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rejects unauthenticated users', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: null }, error: null })
+
+    const { GET } = await loadRoute()
+    const res = await GET(new Request('http://localhost/api/garmin/first-aha?userId=1'))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns stable response shape for authenticated users', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
+    getGarminOAuthStateMock.mockResolvedValueOnce({ authUserId: 'auth-1', profileId: 10 })
+    generateGarminFirstAhaMock.mockResolvedValueOnce({
+      status: 'partial',
+      generatedAt: '2026-06-30T12:00:00.000Z',
+      dataWindow: { activitiesDays: 28 },
+      profile: {
+        runnerType: 'Building consistency',
+        headline: 'Building consistency based on your recent Garmin runs',
+        summaryBullets: ['2 runs in the last 14 days'],
+        confidence: 'medium',
+      },
+      signals: {
+        consistency: { runsLast14Days: 1, runsLast28Days: 2, weeklyPatternLabel: 'Low' },
+        load: { acwrLabel: 'stable' },
+        intensity: { label: 'Mixed', source: 'insufficient' },
+      },
+      guardrails: { level: 'green', message: 'Stable', reasons: [] },
+      starterPlan: { title: '14-day block', rationale: 'Easy', days: [] },
+      recommendedChallenge: {
+        id: 'start-running',
+        title: 'Start Running',
+        reason: 'Fit',
+        fitScoreLabel: 'Good fit',
+      },
+      disclaimers: [],
+    })
+
+    const { GET } = await loadRoute()
+    const res = await GET(
+      new Request('http://localhost/api/garmin/first-aha?userId=1', {
+        headers: { 'x-user-id': '1' },
+      })
+    )
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.status).toBe('partial')
+    expect(body.profile.runnerType).toBeTruthy()
+    expect(body.recommendedChallenge.id).toBe('start-running')
+  })
+
+  it('returns insufficient_data without 500 for empty history', async () => {
+    getUserMock.mockResolvedValueOnce({ data: { user: { id: 'auth-1' } }, error: null })
+    getGarminOAuthStateMock.mockResolvedValueOnce({ authUserId: 'auth-1', profileId: 10 })
+    generateGarminFirstAhaMock.mockResolvedValueOnce({
+      status: 'insufficient_data',
+      generatedAt: '2026-06-30T12:00:00.000Z',
+      dataWindow: { activitiesDays: 28 },
+      profile: {
+        runnerType: 'Getting started',
+        headline: 'Getting started',
+        summaryBullets: [],
+        confidence: 'low',
+      },
+      signals: {
+        consistency: { runsLast14Days: 0, runsLast28Days: 0, weeklyPatternLabel: 'None' },
+        load: { acwrLabel: 'unknown' },
+        intensity: { label: 'No data', source: 'insufficient' },
+      },
+      guardrails: { level: 'yellow', message: 'Limited data', reasons: [] },
+      starterPlan: { title: 'Starter', rationale: 'Conservative', days: [] },
+      recommendedChallenge: {
+        id: 'start-running',
+        title: 'Start Running',
+        reason: 'Safe start',
+        fitScoreLabel: 'Good fit',
+      },
+      disclaimers: [],
+    })
+
+    const { GET } = await loadRoute()
+    const res = await GET(new Request('http://localhost/api/garmin/first-aha?userId=1'))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.status).toBe('insufficient_data')
+  })
+})

--- a/v0/app/api/garmin/first-aha/route.ts
+++ b/v0/app/api/garmin/first-aha/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server'
+
+import { generateGarminFirstAha } from '@/lib/server/garmin-first-aha-service'
+import { getGarminOAuthState } from '@/lib/server/garmin-oauth-store'
+import { createClient } from '@/lib/supabase/server'
+
+export const dynamic = 'force-dynamic'
+
+function parseUserId(req: Request): number | null {
+  const headerValue = req.headers.get('x-user-id')?.trim() ?? ''
+  if (headerValue) {
+    const parsed = Number.parseInt(headerValue, 10)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+
+  const queryValue = new URL(req.url).searchParams.get('userId')?.trim() ?? ''
+  if (!queryValue) return null
+
+  const parsed = Number.parseInt(queryValue, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+export async function GET(req: Request) {
+  const userId = parseUserId(req)
+  if (!userId) {
+    return NextResponse.json({ error: 'Valid userId is required' }, { status: 400 })
+  }
+
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const oauthState = await getGarminOAuthState(userId)
+  if (!oauthState) {
+    return NextResponse.json({ error: 'Garmin connection not found' }, { status: 404 })
+  }
+
+  if (oauthState.authUserId && oauthState.authUserId !== user.id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const result = await generateGarminFirstAha(userId)
+    if (result.status === 'error') {
+      return NextResponse.json(result, { status: 404 })
+    }
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('[api/garmin/first-aha] Failed:', error)
+    return NextResponse.json(
+      {
+        status: 'error',
+        error: 'Failed to generate Garmin First Aha result',
+        detail: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/v0/app/api/garmin/first-aha/route.ts
+++ b/v0/app/api/garmin/first-aha/route.ts
@@ -41,7 +41,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Garmin connection not found' }, { status: 404 })
   }
 
-  if (oauthState.authUserId && oauthState.authUserId !== user.id) {
+  if (oauthState.authUserId !== user.id) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 

--- a/v0/app/api/garmin/first-aha/route.ts
+++ b/v0/app/api/garmin/first-aha/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-import { generateGarminFirstAha } from '@/lib/server/garmin-first-aha-service'
+import { buildUnavailableGarminFirstAha, generateGarminFirstAha } from '@/lib/server/garmin-first-aha-service'
 import { getGarminOAuthState } from '@/lib/server/garmin-oauth-store'
 import { createClient } from '@/lib/supabase/server'
 
@@ -38,7 +38,7 @@ export async function GET(req: Request) {
 
   const oauthState = await getGarminOAuthState(userId)
   if (!oauthState) {
-    return NextResponse.json({ error: 'Garmin connection not found' }, { status: 404 })
+    return NextResponse.json(buildUnavailableGarminFirstAha(), { status: 404 })
   }
 
   if (oauthState.authUserId !== user.id) {
@@ -46,10 +46,7 @@ export async function GET(req: Request) {
   }
 
   try {
-    const result = await generateGarminFirstAha(userId)
-    if (result.status === 'error') {
-      return NextResponse.json(result, { status: 404 })
-    }
+    const result = await generateGarminFirstAha(userId, oauthState)
     return NextResponse.json(result)
   } catch (error) {
     console.error('[api/garmin/first-aha] Failed:', error)

--- a/v0/app/garmin/callback/page.tsx
+++ b/v0/app/garmin/callback/page.tsx
@@ -118,7 +118,11 @@ function GarminCallbackContent() {
         setMessage("Garmin connected. Redirecting...")
 
         setTimeout(() => {
-          const destination = hasSeenGarminFirstAha() ? "/?screen=profile" : "/garmin/first-aha"
+          const callbackUserId = typeof data.userId === "number" ? data.userId : null
+          const destination =
+            callbackUserId != null && hasSeenGarminFirstAha(callbackUserId)
+              ? "/?screen=profile"
+              : "/garmin/first-aha"
           router.replace(destination)
         }, 1200)
       } catch (error) {

--- a/v0/app/garmin/callback/page.tsx
+++ b/v0/app/garmin/callback/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import { db, type WearableDevice } from "@/lib/db"
 import { trackAnalyticsEvent } from "@/lib/analytics"
+import { hasSeenGarminFirstAha } from "@/lib/garminFirstAhaStorage"
 
 type CallbackStatus = "processing" | "success" | "error"
 
@@ -117,7 +118,8 @@ function GarminCallbackContent() {
         setMessage("Garmin connected. Redirecting...")
 
         setTimeout(() => {
-          router.replace("/?screen=profile")
+          const destination = hasSeenGarminFirstAha() ? "/?screen=profile" : "/garmin/first-aha"
+          router.replace(destination)
         }, 1200)
       } catch (error) {
         setStatus("error")

--- a/v0/app/garmin/first-aha/page.tsx
+++ b/v0/app/garmin/first-aha/page.tsx
@@ -1,0 +1,5 @@
+import { GarminFirstAhaScreen } from '@/components/garmin-first-aha-screen'
+
+export default function GarminFirstAhaPage() {
+  return <GarminFirstAhaScreen />
+}

--- a/v0/components/garmin-first-aha-screen.tsx
+++ b/v0/components/garmin-first-aha-screen.tsx
@@ -1,0 +1,339 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { AlertTriangle, CheckCircle2, Loader2, RefreshCw, SkipForward } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useToast } from '@/components/ui/use-toast'
+import { useData } from '@/contexts/DataContext'
+import { trackAnalyticsEvent } from '@/lib/analytics'
+import { acceptGarminFirstAhaPlan, startGarminFirstAhaChallenge } from '@/lib/garminFirstAhaClient'
+import { markGarminFirstAhaSeen } from '@/lib/garminFirstAhaStorage'
+import type { GarminFirstAhaResult } from '@/lib/garminFirstAhaTypes'
+import { getActivePlan } from '@/lib/dbUtils'
+
+type ScreenPhase = 'loading' | 'ready' | 'error'
+
+const LOADING_STEPS = [
+  'Reading your recent Garmin runs',
+  'Checking consistency and load',
+  'Reviewing recovery signals',
+  'Drafting your 14-day starter block',
+]
+
+function guardrailClass(level: GarminFirstAhaResult['guardrails']['level']): string {
+  if (level === 'green') return 'border-green-200 bg-green-50 text-green-900'
+  if (level === 'yellow') return 'border-amber-200 bg-amber-50 text-amber-900'
+  return 'border-red-200 bg-red-50 text-red-900'
+}
+
+export function GarminFirstAhaScreen() {
+  const router = useRouter()
+  const { toast } = useToast()
+  const { userId, refresh } = useData()
+  const [phase, setPhase] = useState<ScreenPhase>('loading')
+  const [loadingStep, setLoadingStep] = useState(0)
+  const [result, setResult] = useState<GarminFirstAhaResult | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [hasActivePlan, setHasActivePlan] = useState(false)
+  const [isAccepting, setIsAccepting] = useState(false)
+  const [isStartingChallenge, setIsStartingChallenge] = useState(false)
+  const [showReplaceConfirm, setShowReplaceConfirm] = useState(false)
+
+  const analyticsProps = useMemo(
+    () => ({
+      activity_count_28d: result?.signals.consistency.runsLast28Days,
+      has_wellness_data: Boolean(result?.signals.recovery),
+      guardrail_level: result?.guardrails.level,
+      runner_type: result?.profile.runnerType,
+      recommended_challenge_id: result?.recommendedChallenge.id,
+      plan_days_count: result?.starterPlan.days.length,
+    }),
+    [result]
+  )
+
+  const loadResult = useCallback(async () => {
+    if (!userId) return
+    setPhase('loading')
+    setErrorMessage(null)
+
+    try {
+      const response = await fetch(`/api/garmin/first-aha?userId=${userId}`, {
+        headers: { 'x-user-id': String(userId) },
+        credentials: 'include',
+      })
+      const data = (await response.json()) as GarminFirstAhaResult & { error?: string }
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to load Garmin First Aha')
+      }
+
+      setResult(data)
+      setPhase('ready')
+
+      const activePlan = await getActivePlan(userId)
+      setHasActivePlan(Boolean(activePlan?.id))
+
+      void trackAnalyticsEvent('garmin_first_aha_viewed', {
+        activity_count_28d: data.signals.consistency.runsLast28Days,
+        has_wellness_data: Boolean(data.signals.recovery),
+        guardrail_level: data.guardrails.level,
+        runner_type: data.profile.runnerType,
+        recommended_challenge_id: data.recommendedChallenge.id,
+        plan_days_count: data.starterPlan.days.length,
+      })
+      if (data.status === 'partial') {
+        void trackAnalyticsEvent('garmin_first_aha_partial_data', {
+          activity_count_28d: data.signals.consistency.runsLast28Days,
+          has_wellness_data: Boolean(data.signals.recovery),
+        })
+      }
+      void trackAnalyticsEvent('garmin_first_aha_generated', {
+        status: data.status,
+        activity_count_28d: data.signals.consistency.runsLast28Days,
+      })
+    } catch (error) {
+      setPhase('error')
+      setErrorMessage(error instanceof Error ? error.message : 'Something went wrong')
+      void trackAnalyticsEvent('garmin_first_aha_error', {
+        message: error instanceof Error ? error.message : 'unknown',
+      })
+    }
+  }, [userId])
+
+  useEffect(() => {
+    if (!userId) return
+    void loadResult()
+  }, [loadResult, userId])
+
+  useEffect(() => {
+    if (phase !== 'loading') return
+    const interval = window.setInterval(() => {
+      setLoadingStep((current) => (current + 1) % LOADING_STEPS.length)
+    }, 900)
+    return () => window.clearInterval(interval)
+  }, [phase])
+
+  const handleSkip = () => {
+    markGarminFirstAhaSeen()
+    void trackAnalyticsEvent('garmin_first_aha_skipped', analyticsProps)
+    router.replace('/?screen=profile')
+  }
+
+  const handleAcceptPlan = async (replaceExisting = false) => {
+    if (!userId || !result) return
+    if (hasActivePlan && !replaceExisting) {
+      setShowReplaceConfirm(true)
+      return
+    }
+
+    setIsAccepting(true)
+    try {
+      await acceptGarminFirstAhaPlan({ userId, result, replaceExisting })
+      markGarminFirstAhaSeen()
+      await refresh()
+      void trackAnalyticsEvent('garmin_first_aha_plan_accepted', analyticsProps)
+      toast({
+        title: 'Starter plan saved',
+        description: 'Your 14-day Garmin-based block is ready on Today.',
+      })
+      router.replace('/')
+    } catch (error) {
+      if (error instanceof Error && error.message === 'ACTIVE_PLAN_EXISTS') {
+        setShowReplaceConfirm(true)
+        return
+      }
+      toast({
+        title: 'Could not save plan',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsAccepting(false)
+    }
+  }
+
+  const handleStartChallenge = async () => {
+    if (!userId || !result) return
+    setIsStartingChallenge(true)
+    try {
+      await startGarminFirstAhaChallenge({
+        userId,
+        challengeSlug: result.recommendedChallenge.id,
+      })
+      markGarminFirstAhaSeen()
+      void trackAnalyticsEvent('garmin_first_aha_challenge_started', analyticsProps)
+      toast({
+        title: 'Challenge started',
+        description: result.recommendedChallenge.title,
+      })
+      router.replace('/?screen=profile')
+    } catch (error) {
+      toast({
+        title: 'Could not start challenge',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      })
+    } finally {
+      setIsStartingChallenge(false)
+    }
+  }
+
+  if (!userId) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-xl items-center justify-center p-6">
+        <p className="text-sm text-gray-600">Sign in to view your Garmin running profile.</p>
+      </main>
+    )
+  }
+
+  if (phase === 'loading') {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-xl flex-col justify-center gap-4 p-6">
+        <div className="rounded-xl border bg-white p-6 shadow-sm">
+          <div className="flex items-center gap-3">
+            <Loader2 className="h-5 w-5 animate-spin text-blue-600" />
+            <h1 className="text-lg font-semibold text-gray-900">Reading your recent Garmin runs</h1>
+          </div>
+          <p className="mt-3 text-sm text-gray-600">{LOADING_STEPS[loadingStep]}</p>
+        </div>
+      </main>
+    )
+  }
+
+  if (phase === 'error' || !result) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-xl flex-col justify-center gap-4 p-6">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 text-red-600" />
+            <div>
+              <h1 className="text-lg font-semibold text-red-900">Could not build your profile</h1>
+              <p className="mt-2 text-sm text-red-800">{errorMessage}</p>
+            </div>
+          </div>
+          <div className="mt-4 flex gap-2">
+            <Button variant="outline" onClick={() => void loadResult()}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Retry
+            </Button>
+            <Button variant="ghost" onClick={handleSkip}>
+              Skip for now
+            </Button>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  const statusLabel =
+    result.status === 'ready'
+      ? 'Ready'
+      : result.status === 'partial'
+        ? 'Partial data'
+        : result.status === 'insufficient_data'
+          ? 'Limited history'
+          : 'Unavailable'
+
+  return (
+    <main className="mx-auto min-h-screen max-w-xl p-4 pb-24 sm:p-6">
+      <div className="space-y-4">
+        <header className="space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-blue-700">Garmin connected</p>
+          <h1 className="text-2xl font-semibold text-gray-900">Your running profile</h1>
+          <p className="text-sm text-gray-600">{result.profile.headline}</p>
+          <span className="inline-flex rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700">
+            {statusLabel}
+          </span>
+        </header>
+
+        <section className="rounded-xl border bg-white p-4 shadow-sm">
+          <h2 className="text-sm font-semibold text-gray-900">{result.profile.runnerType}</h2>
+          <ul className="mt-3 space-y-2 text-sm text-gray-700">
+            {result.profile.summaryBullets.map((bullet) => (
+              <li key={bullet} className="flex gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-blue-600" />
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section className={`rounded-xl border p-4 ${guardrailClass(result.guardrails.level)}`}>
+          <h2 className="text-sm font-semibold">Safety read</h2>
+          <p className="mt-2 text-sm">{result.guardrails.message}</p>
+        </section>
+
+        <section className="rounded-xl border bg-white p-4 shadow-sm">
+          <h2 className="text-sm font-semibold text-gray-900">{result.starterPlan.title}</h2>
+          <p className="mt-1 text-sm text-gray-600">{result.starterPlan.rationale}</p>
+          <div className="mt-3 space-y-2">
+            {result.starterPlan.days.slice(0, 8).map((day) => (
+              <div key={`${day.date}-${day.label}`} className="flex items-center justify-between text-sm">
+                <div>
+                  <p className="font-medium text-gray-900">{day.label}</p>
+                  <p className="text-xs text-gray-500">{day.date}</p>
+                </div>
+                <p className="text-right text-gray-700">{day.target ?? 'Rest'}</p>
+              </div>
+            ))}
+            {result.starterPlan.days.length > 8 && (
+              <p className="text-xs text-gray-500">+ {result.starterPlan.days.length - 8} more sessions in this block</p>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-xl border bg-white p-4 shadow-sm">
+          <h2 className="text-sm font-semibold text-gray-900">Recommended challenge</h2>
+          <p className="mt-1 text-base font-medium text-gray-900">{result.recommendedChallenge.title}</p>
+          <p className="mt-2 text-sm text-gray-600">{result.recommendedChallenge.reason}</p>
+          <p className="mt-2 text-xs text-gray-500">{result.recommendedChallenge.fitScoreLabel}</p>
+        </section>
+
+        {result.disclaimers.length > 0 && (
+          <p className="text-xs text-gray-500">{result.disclaimers.join(' ')}</p>
+        )}
+
+        {showReplaceConfirm && (
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+            <p className="font-medium">You already have an active plan.</p>
+            <p className="mt-1">Review and replace it with this 14-day Garmin starter block?</p>
+            <div className="mt-3 flex gap-2">
+              <Button size="sm" onClick={() => void handleAcceptPlan(true)} disabled={isAccepting}>
+                Review and replace
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setShowReplaceConfirm(false)}>
+                Keep current plan
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div className="sticky bottom-0 space-y-2 border-t bg-gray-50 p-4 sm:static sm:border-0 sm:bg-transparent sm:p-0">
+          <Button className="w-full" onClick={() => void handleAcceptPlan()} disabled={isAccepting}>
+            {isAccepting ? 'Saving plan...' : 'Accept 14-day plan'}
+          </Button>
+          <Button
+            className="w-full"
+            variant="secondary"
+            onClick={() => void handleStartChallenge()}
+            disabled={isStartingChallenge}
+          >
+            {isStartingChallenge ? 'Starting challenge...' : 'Start recommended challenge'}
+          </Button>
+          <div className="flex gap-2">
+            <Button className="flex-1" variant="outline" asChild>
+              <Link href="/?screen=onboarding">Adjust goal</Link>
+            </Button>
+            <Button className="flex-1" variant="ghost" onClick={handleSkip}>
+              <SkipForward className="mr-2 h-4 w-4" />
+              Skip for now
+            </Button>
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/v0/components/garmin-first-aha-screen.tsx
+++ b/v0/components/garmin-first-aha-screen.tsx
@@ -65,8 +65,13 @@ export function GarminFirstAhaScreen() {
         credentials: 'include',
       })
       const data = (await response.json()) as GarminFirstAhaResult & { error?: string }
+      const isFirstAhaResult =
+        typeof (data as { status?: unknown }).status === 'string' &&
+        ['ready', 'partial', 'insufficient_data', 'error'].includes(
+          (data as { status: string }).status
+        )
 
-      if (!response.ok) {
+      if (!response.ok && !isFirstAhaResult) {
         throw new Error(data.error || 'Failed to load Garmin First Aha')
       }
 
@@ -117,7 +122,7 @@ export function GarminFirstAhaScreen() {
   }, [phase])
 
   const handleSkip = () => {
-    markGarminFirstAhaSeen()
+    if (userId) markGarminFirstAhaSeen(userId)
     void trackAnalyticsEvent('garmin_first_aha_skipped', analyticsProps)
     router.replace('/?screen=profile')
   }
@@ -132,7 +137,7 @@ export function GarminFirstAhaScreen() {
     setIsAccepting(true)
     try {
       await acceptGarminFirstAhaPlan({ userId, result, replaceExisting })
-      markGarminFirstAhaSeen()
+      markGarminFirstAhaSeen(userId)
       await refresh()
       void trackAnalyticsEvent('garmin_first_aha_plan_accepted', analyticsProps)
       toast({
@@ -163,7 +168,7 @@ export function GarminFirstAhaScreen() {
         userId,
         challengeSlug: result.recommendedChallenge.id,
       })
-      markGarminFirstAhaSeen()
+      markGarminFirstAhaSeen(userId)
       void trackAnalyticsEvent('garmin_first_aha_challenge_started', analyticsProps)
       toast({
         title: 'Challenge started',
@@ -312,17 +317,25 @@ export function GarminFirstAhaScreen() {
         )}
 
         <div className="sticky bottom-0 space-y-2 border-t bg-gray-50 p-4 sm:static sm:border-0 sm:bg-transparent sm:p-0">
-          <Button className="w-full" onClick={() => void handleAcceptPlan()} disabled={isAccepting}>
-            {isAccepting ? 'Saving plan...' : 'Accept 14-day plan'}
-          </Button>
-          <Button
-            className="w-full"
-            variant="secondary"
-            onClick={() => void handleStartChallenge()}
-            disabled={isStartingChallenge}
-          >
-            {isStartingChallenge ? 'Starting challenge...' : 'Start recommended challenge'}
-          </Button>
+          {result.status === 'error' ? (
+            <Button className="w-full" asChild>
+              <Link href="/?screen=profile">Connect Garmin</Link>
+            </Button>
+          ) : (
+            <>
+              <Button className="w-full" onClick={() => void handleAcceptPlan()} disabled={isAccepting}>
+                {isAccepting ? 'Saving plan...' : 'Accept 14-day plan'}
+              </Button>
+              <Button
+                className="w-full"
+                variant="secondary"
+                onClick={() => void handleStartChallenge()}
+                disabled={isStartingChallenge}
+              >
+                {isStartingChallenge ? 'Starting challenge...' : 'Start recommended challenge'}
+              </Button>
+            </>
+          )}
           <div className="flex gap-2">
             <Button className="flex-1" variant="outline" asChild>
               <Link href="/?screen=onboarding">Adjust goal</Link>

--- a/v0/lib/garminFirstAha.test.ts
+++ b/v0/lib/garminFirstAha.test.ts
@@ -78,6 +78,33 @@ describe('buildGarminFirstAhaResult', () => {
     expect(result.signals.recovery).toBeUndefined()
     expect(result.disclaimers.some((line) => line.includes('wellness'))).toBe(true)
   })
+
+  it('does not fabricate a pace-based intensity signal from too few heart-rate-tagged runs', () => {
+    const runs = buildRuns(endDate, 2, 7)
+    const result = buildGarminFirstAhaResult({ runs, wellnessDays: [], endDate })
+
+    expect(result.signals.intensity.source).toBe('insufficient')
+  })
+
+  it('falls back to a duration-based longest-run label when distance is missing', () => {
+    const runs: GarminFirstAhaRunInput[] = [
+      {
+        completedAt: `${endDate}T07:00:00.000Z`,
+        durationSeconds: 2400,
+        distanceMeters: null,
+        averageHeartRate: 140,
+      },
+      {
+        completedAt: `${shiftIsoDate(endDate, -2)}T07:00:00.000Z`,
+        durationSeconds: 1200,
+        distanceMeters: null,
+        averageHeartRate: 130,
+      },
+    ]
+    const result = buildGarminFirstAhaResult({ runs, wellnessDays: [], endDate })
+
+    expect(result.signals.load.longestRunLabel).toBe('Longest recent run about 40 min')
+  })
 })
 
 describe('selectRecommendedChallenge', () => {
@@ -134,6 +161,48 @@ describe('computeGuardrails', () => {
 
     expect(guardrails.level).toBe('red')
   })
+
+  it('does not flag yellow for a high hard-run share when recovery signals are strong', () => {
+    // Fixed, stable-zone ACWR fixture and a week1/week2-matched run history so
+    // this test isolates the hard-run-share rule from the volume-spike and
+    // ACWR rules (both of which read from the actual run distribution, not
+    // from hardRunShare) -- those are exercised by other tests already.
+    const stableAcwr = {
+      acuteLoad7d: 100,
+      chronicLoad28d: 100,
+      acwr: 1,
+      monotony7d: 1,
+      strain7d: 100,
+      weeklyVolumeMeters7d: 10000,
+      zone: 'sweet_zone' as const,
+      evidence: { dataPointsUsed: 4, missingDays: 0, confidence: 'high' as const, flags: [], userExplanation: '' },
+      flags: [],
+      insight: '',
+      disclaimer: '',
+      dailyLoads7d: [],
+      dailyLoads28d: [],
+    }
+    const endDate = '2026-06-30'
+    const runs: GarminFirstAhaRunInput[] = [0, -5, -8, -13].map((offset) => ({
+      completedAt: `${shiftIsoDate(endDate, offset)}T07:00:00.000Z`,
+      durationSeconds: 1800,
+      distanceMeters: 5000,
+      averageHeartRate: 170,
+    }))
+
+    const guardrails = computeGuardrails({
+      runs,
+      endDate,
+      acwr: stableAcwr,
+      hardRunShare: 0.5,
+      readinessScore: 80,
+      hasWellness: true,
+      runs28: runs.length,
+    })
+
+    expect(guardrails.level).toBe('green')
+    expect(guardrails.reasons).not.toContain('A high share of recent runs looked hard')
+  })
 })
 
 describe('classifyRunnerType', () => {
@@ -173,5 +242,33 @@ describe('buildStarterPlan', () => {
 
     expect(plan.days.length).toBeGreaterThanOrEqual(6)
     expect(plan.days.some((day) => day.type === 'rest')).toBe(true)
+  })
+
+  it('still includes a rest day at 4 sessions per week (session/rest offset collision)', () => {
+    const plan = buildStarterPlan({
+      runnerType: 'consistent_base_builder',
+      guardrailLevel: 'green',
+      runs28: 16,
+      startDate: '2026-07-01',
+    })
+    const week1End = shiftIsoDate('2026-07-01', 7)
+    const week1 = plan.days.filter((day) => day.date < week1End)
+
+    expect(week1.some((day) => day.type === 'rest')).toBe(true)
+  })
+
+  it('reaches 5 sessions per week for very high-frequency runners with green guardrails', () => {
+    const plan = buildStarterPlan({
+      runnerType: 'consistent_base_builder',
+      guardrailLevel: 'green',
+      runs28: 20,
+      startDate: '2026-07-01',
+    })
+    const week1End = shiftIsoDate('2026-07-01', 7)
+    const week1 = plan.days.filter((day) => day.date < week1End)
+    const sessionDays = week1.filter((day) => day.type !== 'rest')
+
+    expect(sessionDays.length).toBeGreaterThanOrEqual(5)
+    expect(week1.some((day) => day.type === 'rest')).toBe(true)
   })
 })

--- a/v0/lib/garminFirstAha.test.ts
+++ b/v0/lib/garminFirstAha.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildGarminFirstAhaResult } from '@/lib/garminFirstAhaBuilder'
+import { selectRecommendedChallenge } from '@/lib/garminFirstAhaChallenge'
+import {
+  buildStarterPlan,
+  classifyRunnerType,
+  computeGuardrails,
+  shiftIsoDate,
+} from '@/lib/garminFirstAhaPlan'
+import { computeGarminAcwrMetrics } from '@/lib/garminAcwr'
+import type { GarminFirstAhaRunInput } from '@/lib/garminFirstAhaTypes'
+
+function buildRuns(endDate: string, count: number, spacingDays = 2): GarminFirstAhaRunInput[] {
+  return Array.from({ length: count }, (_, index) => ({
+    completedAt: `${shiftIsoDate(endDate, -(index * spacingDays))}T07:00:00.000Z`,
+    durationSeconds: 1800,
+    distanceMeters: 5000,
+    averageHeartRate: 135,
+  }))
+}
+
+describe('buildGarminFirstAhaResult', () => {
+  const endDate = '2026-06-30'
+
+  it('returns insufficient_data for empty history with a useful partial result', () => {
+    const result = buildGarminFirstAhaResult({
+      runs: [],
+      wellnessDays: [],
+      endDate,
+      generatedAt: '2026-06-30T12:00:00.000Z',
+    })
+
+    expect(result.status).toBe('insufficient_data')
+    expect(result.profile.summaryBullets.length).toBeGreaterThan(0)
+    expect(result.starterPlan.days.length).toBeGreaterThan(0)
+    expect(result.recommendedChallenge.id).toBeTruthy()
+  })
+
+  it('returns a conservative plan for low-frequency runners', () => {
+    const runs = buildRuns(endDate, 2, 7)
+    const result = buildGarminFirstAhaResult({ runs, wellnessDays: [], endDate })
+
+    expect(result.status).toBe('partial')
+    expect(result.starterPlan.days.some((day) => day.type === 'walk_run' || day.type === 'easy_run')).toBe(
+      true
+    )
+    expect(result.guardrails.level).not.toBe('red')
+  })
+
+  it('produces yellow guardrails for elevated load', () => {
+    const spikeRuns = [
+      ...buildRuns(endDate, 5, 1),
+      ...Array.from({ length: 3 }, (_, index) => ({
+        completedAt: `${shiftIsoDate(endDate, -index)}T07:00:00.000Z`,
+        durationSeconds: 5400,
+        distanceMeters: 15000,
+        averageHeartRate: 175,
+      })),
+    ]
+
+    const result = buildGarminFirstAhaResult({
+      runs: spikeRuns,
+      wellnessDays: [],
+      endDate,
+    })
+
+    expect(['yellow', 'red']).toContain(result.guardrails.level)
+    expect(result.signals.load.acwrLabel).toBe('elevated')
+  })
+
+  it('lowers confidence without blocking when wellness data is missing', () => {
+    const runs = buildRuns(endDate, 10, 2)
+    const result = buildGarminFirstAhaResult({ runs, wellnessDays: [], endDate })
+
+    expect(result.status).toBe('partial')
+    expect(result.profile.confidence).not.toBe('high')
+    expect(result.signals.recovery).toBeUndefined()
+    expect(result.disclaimers.some((line) => line.includes('wellness'))).toBe(true)
+  })
+})
+
+describe('selectRecommendedChallenge', () => {
+  it('maps low frequency to start-running', () => {
+    const challenge = selectRecommendedChallenge({
+      runnerType: 'new_or_low_data_runner',
+      guardrailLevel: 'green',
+      runs28: 2,
+      gapDays: null,
+    })
+
+    expect(challenge.id).toBe('start-running')
+  })
+
+  it('maps elevated load to plateau-breaker', () => {
+    const challenge = selectRecommendedChallenge({
+      runnerType: 'overreaching_risk',
+      guardrailLevel: 'yellow',
+      runs28: 10,
+      gapDays: 2,
+    })
+
+    expect(challenge.id).toBe('plateau-breaker')
+  })
+})
+
+describe('computeGuardrails', () => {
+  it('marks severe load spike with red when recovery is weak', () => {
+    const endDate = '2026-06-30'
+    const runs = buildRuns(endDate, 12, 1).map((run, index) => ({
+      ...run,
+      distanceMeters: index < 4 ? 12000 : 5000,
+      averageHeartRate: 170,
+    }))
+    const acwr = computeGarminAcwrMetrics({
+      activities: runs.map((run) => ({
+        startTime: run.completedAt,
+        durationSeconds: run.durationSeconds,
+        averageHeartRate: run.averageHeartRate,
+        distanceMeters: run.distanceMeters,
+      })),
+      endDate,
+    })
+
+    const guardrails = computeGuardrails({
+      runs,
+      endDate,
+      acwr,
+      hardRunShare: 0.5,
+      readinessScore: 30,
+      hasWellness: true,
+      runs28: runs.length,
+    })
+
+    expect(guardrails.level).toBe('red')
+  })
+})
+
+describe('classifyRunnerType', () => {
+  it('classifies sparse history as new_or_low_data_runner', () => {
+    const endDate = '2026-06-30'
+    const runs = buildRuns(endDate, 2)
+    const acwr = computeGarminAcwrMetrics({
+      activities: runs.map((run) => ({
+        startTime: run.completedAt,
+        durationSeconds: run.durationSeconds,
+        averageHeartRate: run.averageHeartRate,
+        distanceMeters: run.distanceMeters,
+      })),
+      endDate,
+    })
+
+    expect(
+      classifyRunnerType({
+        runs,
+        endDate,
+        acwr,
+        hardRunShare: 0.1,
+        readinessScore: null,
+      })
+    ).toBe('new_or_low_data_runner')
+  })
+})
+
+describe('buildStarterPlan', () => {
+  it('includes rest days in a 14-day block', () => {
+    const plan = buildStarterPlan({
+      runnerType: 'building_consistency',
+      guardrailLevel: 'green',
+      runs28: 8,
+      startDate: '2026-07-01',
+    })
+
+    expect(plan.days.length).toBeGreaterThanOrEqual(6)
+    expect(plan.days.some((day) => day.type === 'rest')).toBe(true)
+  })
+})

--- a/v0/lib/garminFirstAhaBuilder.ts
+++ b/v0/lib/garminFirstAhaBuilder.ts
@@ -2,6 +2,7 @@ import {
   analyzeGarminFirstAhaInputs,
   buildProfileSummary,
   buildStarterPlan,
+  daysSinceLastRun,
   shiftIsoDate,
 } from '@/lib/garminFirstAhaPlan'
 import { selectRecommendedChallenge } from '@/lib/garminFirstAhaChallenge'
@@ -13,24 +14,6 @@ import {
   type GarminFirstAhaStatus,
   type GarminFirstAhaWellnessDay,
 } from '@/lib/garminFirstAhaTypes'
-
-function toDateKey(value: string): string {
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) return new Date().toISOString().slice(0, 10)
-  return parsed.toISOString().slice(0, 10)
-}
-
-function daysSinceLastRun(runs: GarminFirstAhaRunInput[], endDate: string): number | null {
-  if (runs.length === 0) return null
-  const latest = runs
-    .map((run) => toDateKey(run.completedAt))
-    .sort()
-    .at(-1)
-  if (!latest) return null
-  const endMs = Date.parse(`${endDate}T00:00:00.000Z`)
-  const latestMs = Date.parse(`${latest}T00:00:00.000Z`)
-  return Math.round((endMs - latestMs) / (24 * 60 * 60 * 1000))
-}
 
 export function buildGarminFirstAhaResult(params: {
   runs: GarminFirstAhaRunInput[]

--- a/v0/lib/garminFirstAhaBuilder.ts
+++ b/v0/lib/garminFirstAhaBuilder.ts
@@ -1,0 +1,131 @@
+import {
+  analyzeGarminFirstAhaInputs,
+  buildProfileSummary,
+  buildStarterPlan,
+  shiftIsoDate,
+} from '@/lib/garminFirstAhaPlan'
+import { selectRecommendedChallenge } from '@/lib/garminFirstAhaChallenge'
+import {
+  MEDICAL_DISCLAIMER,
+  RUNNER_TYPE_LABELS,
+  type GarminFirstAhaResult,
+  type GarminFirstAhaRunInput,
+  type GarminFirstAhaStatus,
+  type GarminFirstAhaWellnessDay,
+} from '@/lib/garminFirstAhaTypes'
+
+function toDateKey(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return new Date().toISOString().slice(0, 10)
+  return parsed.toISOString().slice(0, 10)
+}
+
+function daysSinceLastRun(runs: GarminFirstAhaRunInput[], endDate: string): number | null {
+  if (runs.length === 0) return null
+  const latest = runs
+    .map((run) => toDateKey(run.completedAt))
+    .sort()
+    .at(-1)
+  if (!latest) return null
+  const endMs = Date.parse(`${endDate}T00:00:00.000Z`)
+  const latestMs = Date.parse(`${latest}T00:00:00.000Z`)
+  return Math.round((endMs - latestMs) / (24 * 60 * 60 * 1000))
+}
+
+export function buildGarminFirstAhaResult(params: {
+  runs: GarminFirstAhaRunInput[]
+  wellnessDays: GarminFirstAhaWellnessDay[]
+  endDate?: string
+  generatedAt?: string
+}): GarminFirstAhaResult {
+  const generatedAt = params.generatedAt ?? new Date().toISOString()
+  const analysis = analyzeGarminFirstAhaInputs(params)
+
+  let status: GarminFirstAhaStatus = 'ready'
+  if (analysis.runs28 === 0) {
+    status = 'insufficient_data'
+  } else if (analysis.runs28 < 3 || !analysis.hasWellness) {
+    status = 'partial'
+  }
+
+  const profileSummary = buildProfileSummary({
+    runnerType: analysis.runnerType,
+    runs14: analysis.runs14,
+    runs28: analysis.runs28,
+    weeklyPatternLabel: analysis.weeklyPatternLabel,
+    guardrailMessage: analysis.guardrails.message,
+    confidence: analysis.confidence,
+  })
+
+  const startDate = shiftIsoDate(analysis.endDate, 1)
+  const starterPlan = buildStarterPlan({
+    runnerType: analysis.runnerType,
+    guardrailLevel: analysis.guardrails.level,
+    runs28: analysis.runs28,
+    startDate,
+  })
+
+  const recommendedChallenge = selectRecommendedChallenge({
+    runnerType: analysis.runnerType,
+    guardrailLevel: analysis.guardrails.level,
+    runs28: analysis.runs28,
+    gapDays: daysSinceLastRun(params.runs, analysis.endDate),
+  })
+
+  const disclaimers = [MEDICAL_DISCLAIMER]
+  if (!analysis.hasWellness) {
+    disclaimers.push('Recovery insights are limited because wellness data is not available yet.')
+  }
+  if (analysis.runs28 < 3) {
+    disclaimers.push('Run history is still limited, so recommendations stay conservative.')
+  }
+
+  return {
+    status,
+    generatedAt,
+    dataWindow: {
+      activitiesDays: 28,
+      ...(analysis.wellnessDaysCount > 0 ? { wellnessDays: analysis.wellnessDaysCount } : {}),
+    },
+    profile: {
+      runnerType: RUNNER_TYPE_LABELS[analysis.runnerType],
+      headline: profileSummary.headline,
+      summaryBullets: profileSummary.summaryBullets,
+      confidence: analysis.confidence,
+    },
+    signals: {
+      consistency: {
+        runsLast14Days: analysis.runs14,
+        runsLast28Days: analysis.runs28,
+        weeklyPatternLabel: analysis.weeklyPatternLabel,
+      },
+      load: {
+        ...(analysis.longestRunLabel ? { longestRunLabel: analysis.longestRunLabel } : {}),
+        acwrLabel: analysis.acwrLabel,
+        weeklyDistanceTrend:
+          analysis.acwr.zone === 'elevated' || analysis.acwr.zone === 'high'
+            ? 'Recent volume trending up'
+            : 'Recent volume looks steady',
+      },
+      intensity: {
+        label: analysis.intensity.label,
+        ...(analysis.intensity.easyShare != null ? { easyShare: analysis.intensity.easyShare } : {}),
+        ...(analysis.intensity.hardShare != null ? { hardShare: analysis.intensity.hardShare } : {}),
+        source: analysis.intensity.source,
+      },
+      ...(analysis.hasWellness
+        ? {
+            recovery: {
+              readinessLabel: analysis.readiness.label,
+              availableSignals: [...analysis.availableSignals],
+              missingSignals: [...analysis.missingSignals],
+            },
+          }
+        : {}),
+    },
+    guardrails: analysis.guardrails,
+    starterPlan,
+    recommendedChallenge,
+    disclaimers,
+  }
+}

--- a/v0/lib/garminFirstAhaChallenge.ts
+++ b/v0/lib/garminFirstAhaChallenge.ts
@@ -1,0 +1,54 @@
+import type { GuardrailLevel, RunnerTypeId } from '@/lib/garminFirstAhaTypes'
+import { CHALLENGE_TEMPLATES } from '@/lib/challengeTemplates'
+
+export interface RecommendedChallenge {
+  id: string
+  title: string
+  reason: string
+  fitScoreLabel: string
+}
+
+function templateBySlug(slug: string) {
+  return CHALLENGE_TEMPLATES.find((entry) => entry.slug === slug)
+}
+
+export function selectRecommendedChallenge(params: {
+  runnerType: RunnerTypeId
+  guardrailLevel: GuardrailLevel
+  runs28: number
+  gapDays: number | null
+}): RecommendedChallenge {
+  let slug = 'start-running'
+  let reason = 'A gentle consistency challenge fits your current run frequency.'
+  let fitScoreLabel = 'Good fit'
+
+  if (params.gapDays != null && params.gapDays >= 14) {
+    slug = 'start-running'
+    reason = 'You have a recent gap in running, so a return-to-running challenge is the safest next step.'
+    fitScoreLabel = 'Strong fit'
+  } else if (params.runnerType === 'overreaching_risk' || params.guardrailLevel === 'yellow') {
+    slug = 'plateau-breaker'
+    reason = 'Your recent pattern suggests dialing back intensity before chasing more volume.'
+    fitScoreLabel = 'Strong fit'
+  } else if (params.runnerType === 'consistent_base_builder') {
+    slug = 'morning-ritual'
+    reason = 'Your base looks steady, so a consistency ritual can reinforce easy, repeatable runs.'
+    fitScoreLabel = 'Strong fit'
+  } else if (params.runnerType === 'race_focused') {
+    slug = 'plateau-breaker'
+    reason = 'You already train often; this challenge keeps structure without adding reckless load.'
+    fitScoreLabel = 'Good fit'
+  } else if (params.runs28 >= 3 && params.runs28 < 8) {
+    slug = 'start-running'
+    reason = 'You are building frequency, so a short consistency challenge matches your pattern.'
+    fitScoreLabel = 'Strong fit'
+  }
+
+  const template = templateBySlug(slug) ?? templateBySlug('start-running')
+  return {
+    id: slug,
+    title: template?.name ?? 'Start Running Challenge',
+    reason,
+    fitScoreLabel,
+  }
+}

--- a/v0/lib/garminFirstAhaClient.ts
+++ b/v0/lib/garminFirstAhaClient.ts
@@ -53,7 +53,7 @@ export async function acceptGarminFirstAhaPlan(params: {
     totalWeeks: 2,
     isActive: true,
     planType: 'basic',
-    trainingDaysPerWeek: Math.max(2, Math.min(5, sessionDays.length / 2)),
+    trainingDaysPerWeek: Math.max(2, Math.min(5, Math.round(sessionDays.length / 2))),
     fitnessLevel: 'beginner',
     difficulty: 'beginner',
     complexityLevel: 'basic',

--- a/v0/lib/garminFirstAhaClient.ts
+++ b/v0/lib/garminFirstAhaClient.ts
@@ -1,0 +1,105 @@
+import type { GarminFirstAhaResult, StarterDayType } from '@/lib/garminFirstAhaTypes'
+import { createPlan, createWorkout, getActivePlan } from '@/lib/dbUtils'
+import type { Workout } from '@/lib/db'
+
+const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const
+
+function mapStarterType(type: StarterDayType): Workout['type'] {
+  if (type === 'long_run') return 'long'
+  if (type === 'recovery') return 'recovery'
+  if (type === 'rest') return 'rest'
+  if (type === 'walk_run') return 'easy'
+  return 'easy'
+}
+
+function parseDurationMinutes(target?: string): number | undefined {
+  if (!target) return undefined
+  const match = target.match(/(\d+)\s*-\s*(\d+)\s*min/i) ?? target.match(/(\d+)\s*min/i)
+  if (!match) return undefined
+  if (match[2]) return Number.parseInt(match[2], 10)
+  return Number.parseInt(match[1], 10)
+}
+
+function weekNumberForDate(startDate: Date, sessionDate: Date): number {
+  const diffMs = sessionDate.getTime() - startDate.getTime()
+  const diffDays = Math.floor(diffMs / (24 * 60 * 60 * 1000))
+  return diffDays < 7 ? 1 : 2
+}
+
+export async function acceptGarminFirstAhaPlan(params: {
+  userId: number
+  result: GarminFirstAhaResult
+  replaceExisting?: boolean
+}): Promise<{ planId: number; replacedExisting: boolean }> {
+  const existingPlan = await getActivePlan(params.userId)
+  if (existingPlan?.id && !params.replaceExisting) {
+    throw new Error('ACTIVE_PLAN_EXISTS')
+  }
+
+  const sessionDays = params.result.starterPlan.days.filter((day) => day.type !== 'rest')
+  const startDate = params.result.starterPlan.days[0]
+    ? new Date(`${params.result.starterPlan.days[0].date}T09:00:00.000Z`)
+    : new Date()
+  const endDate = params.result.starterPlan.days.at(-1)
+    ? new Date(`${params.result.starterPlan.days.at(-1)!.date}T09:00:00.000Z`)
+    : new Date(startDate.getTime() + 14 * 24 * 60 * 60 * 1000)
+
+  const planId = await createPlan({
+    userId: params.userId,
+    title: params.result.starterPlan.title,
+    description: params.result.starterPlan.rationale,
+    startDate,
+    endDate,
+    totalWeeks: 2,
+    isActive: true,
+    planType: 'basic',
+    trainingDaysPerWeek: Math.max(2, Math.min(5, sessionDays.length / 2)),
+    fitnessLevel: 'beginner',
+    difficulty: 'beginner',
+    complexityLevel: 'basic',
+    complexityScore: 20,
+  })
+
+  for (const day of params.result.starterPlan.days) {
+    if (day.type === 'rest') continue
+    const scheduledDate = new Date(`${day.date}T09:00:00.000Z`)
+    const week = weekNumberForDate(startDate, scheduledDate)
+    await createWorkout({
+      planId,
+      week,
+      day: DAY_NAMES[scheduledDate.getUTCDay()],
+      type: mapStarterType(day.type),
+      distance: day.type === 'walk_run' ? 2 : day.type === 'long_run' ? 6 : 4,
+      duration: parseDurationMinutes(day.target) ?? 30,
+      intensity: day.intensity === 'hard' ? 'threshold' : day.intensity === 'moderate' ? 'moderate' : 'easy',
+      notes: day.purpose,
+      completed: false,
+      scheduledDate,
+    })
+  }
+
+  return { planId, replacedExisting: Boolean(existingPlan?.id) }
+}
+
+export async function startGarminFirstAhaChallenge(params: {
+  userId: number
+  challengeSlug: string
+}): Promise<void> {
+  const response = await fetch('/api/challenges', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-user-id': String(params.userId),
+    },
+    credentials: 'include',
+    body: JSON.stringify({
+      userId: params.userId,
+      slug: params.challengeSlug,
+    }),
+  })
+
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data?.error || data?.detail || 'Failed to join challenge')
+  }
+}

--- a/v0/lib/garminFirstAhaPlan.ts
+++ b/v0/lib/garminFirstAhaPlan.ts
@@ -1,0 +1,431 @@
+import type {
+  GarminFirstAhaRunInput,
+  GarminFirstAhaWellnessDay,
+  GuardrailLevel,
+  RunnerTypeId,
+  StarterDayType,
+  StarterIntensity,
+} from '@/lib/garminFirstAhaTypes'
+import { RUNNER_TYPE_LABELS } from '@/lib/garminFirstAhaTypes'
+import { computeGarminAcwrMetrics, type GarminAcwrMetrics } from '@/lib/garminAcwr'
+import { computeGarminReadiness } from '@/lib/garminReadinessComputer'
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000
+
+export function shiftIsoDate(dateIso: string, deltaDays: number): string {
+  const parsed = Date.parse(`${dateIso}T00:00:00.000Z`)
+  return new Date(parsed + deltaDays * MILLISECONDS_PER_DAY).toISOString().slice(0, 10)
+}
+
+function toDateKey(value: string): string {
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return new Date().toISOString().slice(0, 10)
+  return parsed.toISOString().slice(0, 10)
+}
+
+function countRunsInWindow(runs: GarminFirstAhaRunInput[], endDate: string, days: number): number {
+  const start = shiftIsoDate(endDate, -(days - 1))
+  return runs.filter((run) => {
+    const key = toDateKey(run.completedAt)
+    return key >= start && key <= endDate
+  }).length
+}
+
+function classifyIntensity(runs: GarminFirstAhaRunInput[]): {
+  label: string
+  easyShare?: number
+  hardShare?: number
+  source: 'heart_rate' | 'pace' | 'mixed' | 'insufficient'
+  hardRunShare: number
+} {
+  const withHr = runs.filter((run) => run.averageHeartRate != null && run.averageHeartRate > 0)
+  if (withHr.length >= 3) {
+    const easy = withHr.filter((run) => (run.averageHeartRate ?? 0) < 140).length
+    const hard = withHr.filter((run) => (run.averageHeartRate ?? 0) >= 165).length
+    const total = withHr.length
+    const easyShare = Math.round((easy / total) * 100)
+    const hardShare = Math.round((hard / total) * 100)
+    let label = 'Balanced intensity mix'
+    if (hardShare >= 40) label = 'Higher intensity share recently'
+    else if (easyShare >= 70) label = 'Mostly easy efforts recently'
+    return { label, easyShare, hardShare, source: 'heart_rate', hardRunShare: hardShare / 100 }
+  }
+
+  if (runs.length >= 2) {
+    return {
+      label: 'Intensity estimated from run patterns',
+      source: 'pace',
+      hardRunShare: 0.2,
+    }
+  }
+
+  return {
+    label: 'Not enough data to assess intensity yet',
+    source: 'insufficient',
+    hardRunShare: 0,
+  }
+}
+
+function daysSinceLastRun(runs: GarminFirstAhaRunInput[], endDate: string): number | null {
+  if (runs.length === 0) return null
+  const latest = runs
+    .map((run) => toDateKey(run.completedAt))
+    .sort()
+    .at(-1)
+  if (!latest) return null
+  const endMs = Date.parse(`${endDate}T00:00:00.000Z`)
+  const latestMs = Date.parse(`${latest}T00:00:00.000Z`)
+  return Math.round((endMs - latestMs) / MILLISECONDS_PER_DAY)
+}
+
+function weeklyFrequencyLabel(runs28: number): string {
+  const perWeek = runs28 / 4
+  if (perWeek < 1) return 'Less than once per week recently'
+  if (perWeek < 2) return 'About once per week recently'
+  if (perWeek < 3) return 'About 2 runs per week recently'
+  if (perWeek < 4.5) return 'About 3 runs per week recently'
+  return '4 or more runs per week recently'
+}
+
+function resolveLongestRunLabel(runs: GarminFirstAhaRunInput[], endDate: string): string | undefined {
+  const start = shiftIsoDate(endDate, -27)
+  const recent = runs.filter((run) => {
+    const key = toDateKey(run.completedAt)
+    return key >= start && key <= endDate
+  })
+  if (recent.length === 0) return undefined
+  const longest = recent.reduce((max, run) => {
+    const meters = run.distanceMeters ?? 0
+    return meters > max ? meters : max
+  }, 0)
+  if (longest <= 0) return 'Longest recent run duration-based'
+  const km = (longest / 1000).toFixed(1)
+  return `Longest recent run about ${km} km`
+}
+
+function mapAcwrLabel(zone: GarminAcwrMetrics['zone']): 'low' | 'stable' | 'elevated' | 'unknown' {
+  if (zone === 'underload') return 'low'
+  if (zone === 'sweet_zone') return 'stable'
+  if (zone === 'elevated' || zone === 'high') return 'elevated'
+  return 'unknown'
+}
+
+export function classifyRunnerType(params: {
+  runs: GarminFirstAhaRunInput[]
+  endDate: string
+  acwr: GarminAcwrMetrics
+  hardRunShare: number
+  readinessScore: number | null
+}): RunnerTypeId {
+  const runs28 = countRunsInWindow(params.runs, params.endDate, 28)
+  const gapDays = daysSinceLastRun(params.runs, params.endDate)
+
+  if (runs28 < 3) return 'new_or_low_data_runner'
+  if (gapDays != null && gapDays >= 14 && runs28 >= 3) return 'building_consistency'
+
+  const elevatedLoad = params.acwr.zone === 'elevated' || params.acwr.zone === 'high'
+  const weakRecovery = params.readinessScore != null && params.readinessScore < 45
+  if (elevatedLoad || (params.hardRunShare >= 0.35 && weakRecovery)) {
+    return 'overreaching_risk'
+  }
+
+  const runsPerWeek = runs28 / 4
+  if (runsPerWeek >= 4 && params.hardRunShare >= 0.25) return 'race_focused'
+  if (runs28 >= 8 && params.hardRunShare < 0.3) return 'consistent_base_builder'
+  return 'building_consistency'
+}
+
+export function computeGuardrails(params: {
+  runs: GarminFirstAhaRunInput[]
+  endDate: string
+  acwr: GarminAcwrMetrics
+  hardRunShare: number
+  readinessScore: number | null
+  hasWellness: boolean
+  runs28: number
+}): { level: GuardrailLevel; message: string; reasons: string[] } {
+  const reasons: string[] = []
+  let level: GuardrailLevel = 'green'
+  const sparseHistory = params.runs28 < 4
+
+  const week1Distance = params.runs
+    .filter((run) => toDateKey(run.completedAt) >= shiftIsoDate(params.endDate, -6))
+    .reduce((sum, run) => sum + (run.distanceMeters ?? 0), 0)
+  const week2Distance = params.runs
+    .filter((run) => {
+      const key = toDateKey(run.completedAt)
+      return key >= shiftIsoDate(params.endDate, -13) && key < shiftIsoDate(params.endDate, -6)
+    })
+    .reduce((sum, run) => sum + (run.distanceMeters ?? 0), 0)
+
+  if (!sparseHistory && week2Distance > 0 && week1Distance > week2Distance * 1.3) {
+    level = 'yellow'
+    reasons.push('Recent weekly volume increased more than about 30%')
+  }
+
+  if (!sparseHistory && (params.acwr.zone === 'elevated' || params.acwr.zone === 'high')) {
+    level = params.acwr.zone === 'high' ? 'red' : 'yellow'
+    reasons.push('Training load looks elevated compared with your recent baseline')
+  }
+
+  if (params.hardRunShare >= 0.35) {
+    if (level === 'green') level = 'yellow'
+    reasons.push('A high share of recent runs looked hard')
+  }
+
+  if (params.readinessScore != null && params.readinessScore < 40) {
+    level = 'red'
+    reasons.push('Recovery signals look weaker than usual')
+  } else if (!params.hasWellness && level === 'green') {
+    reasons.push('Recovery signals are limited, so the plan stays conservative')
+  }
+
+  let message: string
+  if (level === 'red') {
+    message = 'Your recent load and recovery pattern suggest easing up before building again.'
+  } else if (level === 'yellow') {
+    message = 'Your last week jumped quickly, so the plan starts with a lighter reset.'
+  } else if (!params.hasWellness) {
+    message =
+      'You have enough run history for a plan, but not enough wellness data for recovery-based adjustments yet.'
+  } else {
+    message = 'Your recent volume looks stable, so the next two weeks can build gently.'
+  }
+
+  return { level, message, reasons }
+}
+
+function sessionsPerWeek(runnerType: RunnerTypeId, guardrailLevel: GuardrailLevel, runs28: number): number {
+  const basePerWeek = runs28 / 4
+  if (runnerType === 'new_or_low_data_runner') return 2
+  if (guardrailLevel === 'red') return Math.max(2, Math.min(3, Math.round(basePerWeek)))
+  if (guardrailLevel === 'yellow') return Math.max(2, Math.min(3, Math.round(basePerWeek)))
+  if (basePerWeek >= 4) return 4
+  if (basePerWeek >= 2.5) return 3
+  return 2
+}
+
+const DAY_OFFSETS_BY_FREQUENCY: Record<number, number[]> = {
+  2: [1, 4],
+  3: [1, 3, 5],
+  4: [0, 2, 4, 6],
+  5: [0, 1, 3, 5, 6],
+}
+
+function buildSession(
+  date: string,
+  type: StarterDayType,
+  label: string,
+  target: string | undefined,
+  intensity: StarterIntensity,
+  purpose: string
+) {
+  return { date, type, label, target, intensity, purpose }
+}
+
+export function buildStarterPlan(params: {
+  runnerType: RunnerTypeId
+  guardrailLevel: GuardrailLevel
+  runs28: number
+  startDate: string
+}): { title: string; rationale: string; days: ReturnType<typeof buildSession>[] } {
+  const sessions = sessionsPerWeek(params.runnerType, params.guardrailLevel, params.runs28)
+  const week1Offsets = DAY_OFFSETS_BY_FREQUENCY[sessions] ?? DAY_OFFSETS_BY_FREQUENCY[3]
+  const buildWeek = (weekStart: string, weekIndex: number, buildGently: boolean) => {
+    const days: ReturnType<typeof buildSession>[] = []
+    const usedOffsets = new Set<number>()
+
+    for (const offset of week1Offsets) {
+      usedOffsets.add(offset)
+      const date = shiftIsoDate(weekStart, offset)
+      const isWalkRun = params.runnerType === 'new_or_low_data_runner'
+      const easyTarget = buildGently ? '20-25 min easy' : '25-30 min easy'
+      days.push(
+        buildSession(
+          date,
+          isWalkRun ? 'walk_run' : 'easy_run',
+          isWalkRun ? 'Walk-run' : 'Easy run',
+          easyTarget,
+          'easy',
+          weekIndex === 0 ? 'Stabilize your rhythm' : 'Build gently on last week'
+        )
+      )
+    }
+
+    if (sessions >= 3 && params.runnerType !== 'new_or_low_data_runner') {
+      const longOffset = Math.max(...week1Offsets) - 1
+      if (!usedOffsets.has(longOffset) && longOffset >= 0) {
+        const date = shiftIsoDate(weekStart, longOffset)
+        days.push(
+          buildSession(
+            date,
+            'long_run',
+            'Longer easy run',
+            buildGently ? '30-35 min easy' : '35-45 min easy',
+            'easy',
+            'Extend endurance without pushing pace'
+          )
+        )
+      }
+    }
+
+    const restOffset = 6
+    if (!usedOffsets.has(restOffset)) {
+      days.push(
+        buildSession(
+          shiftIsoDate(weekStart, restOffset),
+          'rest',
+          'Rest day',
+          undefined,
+          'rest',
+          'Let your body absorb the work'
+        )
+      )
+    }
+
+    return days.sort((a, b) => a.date.localeCompare(b.date))
+  }
+
+  const week1 = buildWeek(params.startDate, 0, true)
+  const week2Start = shiftIsoDate(params.startDate, 7)
+  const buildWeek2 = params.guardrailLevel === 'green'
+  const week2 = buildWeek(week2Start, 1, !buildWeek2)
+
+  const title =
+    params.guardrailLevel === 'red'
+      ? '14-day lighter reset block'
+      : '14-day adaptive starter block'
+
+  const rationale =
+    params.runnerType === 'new_or_low_data_runner'
+      ? 'Short walk-run sessions to build a safe return rhythm.'
+      : params.guardrailLevel === 'yellow' || params.guardrailLevel === 'red'
+        ? 'Volume stays steady while intensity stays easy while load settles.'
+        : 'Keeps your recent frequency and adds gentle progression in week two.'
+
+  return { title, rationale, days: [...week1, ...week2] }
+}
+
+export function buildProfileSummary(params: {
+  runnerType: RunnerTypeId
+  runs14: number
+  runs28: number
+  weeklyPatternLabel: string
+  guardrailMessage: string
+  confidence: 'high' | 'medium' | 'low'
+}): { headline: string; summaryBullets: string[] } {
+  const label = RUNNER_TYPE_LABELS[params.runnerType]
+  const headline = `${label} based on your recent Garmin runs`
+  const summaryBullets = [
+    `${params.runs14} runs in the last 14 days, ${params.runs28} in the last 28 days.`,
+    params.weeklyPatternLabel,
+    params.guardrailMessage,
+  ]
+  return { headline, summaryBullets }
+}
+
+export function analyzeGarminFirstAhaInputs(params: {
+  runs: GarminFirstAhaRunInput[]
+  wellnessDays: GarminFirstAhaWellnessDay[]
+  endDate?: string
+}) {
+  const endDate =
+    params.endDate ??
+    params.runs
+      .map((run) => toDateKey(run.completedAt))
+      .sort()
+      .at(-1) ??
+    new Date().toISOString().slice(0, 10)
+
+  const runs14 = countRunsInWindow(params.runs, endDate, 14)
+  const runs28 = countRunsInWindow(params.runs, endDate, 28)
+  const weeklyPatternLabel = weeklyFrequencyLabel(runs28)
+
+  const acwr = computeGarminAcwrMetrics({
+    activities: params.runs.map((run) => ({
+      startTime: run.completedAt,
+      durationSeconds: run.durationSeconds,
+      averageHeartRate: run.averageHeartRate,
+      distanceMeters: run.distanceMeters,
+    })),
+    endDate,
+  })
+
+  const dates28 = Array.from({ length: 28 }, (_, index) => shiftIsoDate(endDate, -(27 - index)))
+  const wellnessByDate = new Map(params.wellnessDays.map((day) => [day.date, day]))
+  const readinessDays = dates28.map((date) => {
+    const day = wellnessByDate.get(date)
+    return {
+      date,
+      hrv: day?.hrv ?? null,
+      sleepScore: day?.sleepScore ?? null,
+      restingHr: day?.restingHr ?? null,
+      stress: day?.stress ?? null,
+    }
+  })
+  const readiness = computeGarminReadiness({ days: readinessDays, endDate })
+  const hasWellness = params.wellnessDays.some(
+    (day) => day.hrv != null || day.sleepScore != null || day.restingHr != null || day.stress != null
+  )
+
+  const intensity = classifyIntensity(
+    params.runs.filter((run) => {
+      const key = toDateKey(run.completedAt)
+      return key >= shiftIsoDate(endDate, -27) && key <= endDate
+    })
+  )
+
+  const runnerType = classifyRunnerType({
+    runs: params.runs,
+    endDate,
+    acwr,
+    hardRunShare: intensity.hardRunShare,
+    readinessScore: hasWellness ? readiness.score : null,
+  })
+
+  const guardrails = computeGuardrails({
+    runs: params.runs,
+    endDate,
+    acwr,
+    hardRunShare: intensity.hardRunShare,
+    readinessScore: hasWellness ? readiness.score : null,
+    hasWellness,
+    runs28,
+  })
+
+  const wellnessDaysCount = params.wellnessDays.filter(
+    (day) => day.hrv != null || day.sleepScore != null || day.restingHr != null || day.stress != null
+  ).length
+
+  const recoverySignals = ['hrv', 'sleep', 'resting_hr', 'stress'] as const
+  const availableSignals = recoverySignals.filter((signal) => {
+    if (signal === 'hrv') return params.wellnessDays.some((day) => day.hrv != null)
+    if (signal === 'sleep') return params.wellnessDays.some((day) => day.sleepScore != null)
+    if (signal === 'resting_hr') return params.wellnessDays.some((day) => day.restingHr != null)
+    return params.wellnessDays.some((day) => day.stress != null)
+  })
+  const missingSignals = recoverySignals.filter((signal) => !availableSignals.includes(signal))
+
+  let confidence: 'high' | 'medium' | 'low' = 'low'
+  if (runs28 >= 8 && hasWellness) confidence = 'high'
+  else if (runs28 >= 3) confidence = 'medium'
+
+  return {
+    endDate,
+    runs14,
+    runs28,
+    weeklyPatternLabel,
+    acwr,
+    readiness,
+    hasWellness,
+    wellnessDaysCount,
+    intensity,
+    runnerType,
+    guardrails,
+    availableSignals,
+    missingSignals,
+    confidence,
+    longestRunLabel: resolveLongestRunLabel(params.runs, endDate),
+    acwrLabel: mapAcwrLabel(acwr.zone),
+  }
+}

--- a/v0/lib/garminFirstAhaPlan.ts
+++ b/v0/lib/garminFirstAhaPlan.ts
@@ -17,7 +17,7 @@ export function shiftIsoDate(dateIso: string, deltaDays: number): string {
   return new Date(parsed + deltaDays * MILLISECONDS_PER_DAY).toISOString().slice(0, 10)
 }
 
-function toDateKey(value: string): string {
+export function toDateKey(value: string): string {
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return new Date().toISOString().slice(0, 10)
   return parsed.toISOString().slice(0, 10)
@@ -53,8 +53,8 @@ function classifyIntensity(runs: GarminFirstAhaRunInput[]): {
 
   if (runs.length >= 2) {
     return {
-      label: 'Intensity estimated from run patterns',
-      source: 'pace',
+      label: 'Not enough heart-rate data to assess intensity yet',
+      source: 'insufficient',
       hardRunShare: 0.2,
     }
   }
@@ -66,7 +66,7 @@ function classifyIntensity(runs: GarminFirstAhaRunInput[]): {
   }
 }
 
-function daysSinceLastRun(runs: GarminFirstAhaRunInput[], endDate: string): number | null {
+export function daysSinceLastRun(runs: GarminFirstAhaRunInput[], endDate: string): number | null {
   if (runs.length === 0) return null
   const latest = runs
     .map((run) => toDateKey(run.completedAt))
@@ -98,7 +98,11 @@ function resolveLongestRunLabel(runs: GarminFirstAhaRunInput[], endDate: string)
     const meters = run.distanceMeters ?? 0
     return meters > max ? meters : max
   }, 0)
-  if (longest <= 0) return 'Longest recent run duration-based'
+  if (longest <= 0) {
+    const longestDuration = recent.reduce((max, run) => Math.max(max, run.durationSeconds ?? 0), 0)
+    if (longestDuration <= 0) return undefined
+    return `Longest recent run about ${Math.round(longestDuration / 60)} min`
+  }
   const km = (longest / 1000).toFixed(1)
   return `Longest recent run about ${km} km`
 }
@@ -168,7 +172,9 @@ export function computeGuardrails(params: {
     reasons.push('Training load looks elevated compared with your recent baseline')
   }
 
-  if (params.hardRunShare >= 0.35) {
+  const weakOrMissingRecovery =
+    !params.hasWellness || (params.readinessScore != null && params.readinessScore < 50)
+  if (params.hardRunShare >= 0.35 && weakOrMissingRecovery) {
     if (level === 'green') level = 'yellow'
     reasons.push('A high share of recent runs looked hard')
   }
@@ -200,6 +206,7 @@ function sessionsPerWeek(runnerType: RunnerTypeId, guardrailLevel: GuardrailLeve
   if (runnerType === 'new_or_low_data_runner') return 2
   if (guardrailLevel === 'red') return Math.max(2, Math.min(3, Math.round(basePerWeek)))
   if (guardrailLevel === 'yellow') return Math.max(2, Math.min(3, Math.round(basePerWeek)))
+  if (basePerWeek >= 5) return 5
   if (basePerWeek >= 4) return 4
   if (basePerWeek >= 2.5) return 3
   return 2
@@ -255,6 +262,7 @@ export function buildStarterPlan(params: {
     if (sessions >= 3 && params.runnerType !== 'new_or_low_data_runner') {
       const longOffset = Math.max(...week1Offsets) - 1
       if (!usedOffsets.has(longOffset) && longOffset >= 0) {
+        usedOffsets.add(longOffset)
         const date = shiftIsoDate(weekStart, longOffset)
         days.push(
           buildSession(
@@ -269,7 +277,10 @@ export function buildStarterPlan(params: {
       }
     }
 
-    const restOffset = 6
+    let restOffset = 6
+    while (usedOffsets.has(restOffset) && restOffset > 0) {
+      restOffset -= 1
+    }
     if (!usedOffsets.has(restOffset)) {
       days.push(
         buildSession(

--- a/v0/lib/garminFirstAhaStorage.ts
+++ b/v0/lib/garminFirstAhaStorage.ts
@@ -1,11 +1,11 @@
 export const GARMIN_FIRST_AHA_SEEN_KEY = 'runsmart.garmin-first-aha.seen'
 
-export function hasSeenGarminFirstAha(): boolean {
+export function hasSeenGarminFirstAha(userId: number): boolean {
   if (typeof window === 'undefined') return false
-  return window.localStorage.getItem(GARMIN_FIRST_AHA_SEEN_KEY) === 'true'
+  return window.localStorage.getItem(`${GARMIN_FIRST_AHA_SEEN_KEY}.${userId}`) === 'true'
 }
 
-export function markGarminFirstAhaSeen(): void {
+export function markGarminFirstAhaSeen(userId: number): void {
   if (typeof window === 'undefined') return
-  window.localStorage.setItem(GARMIN_FIRST_AHA_SEEN_KEY, 'true')
+  window.localStorage.setItem(`${GARMIN_FIRST_AHA_SEEN_KEY}.${userId}`, 'true')
 }

--- a/v0/lib/garminFirstAhaStorage.ts
+++ b/v0/lib/garminFirstAhaStorage.ts
@@ -1,0 +1,11 @@
+export const GARMIN_FIRST_AHA_SEEN_KEY = 'runsmart.garmin-first-aha.seen'
+
+export function hasSeenGarminFirstAha(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.localStorage.getItem(GARMIN_FIRST_AHA_SEEN_KEY) === 'true'
+}
+
+export function markGarminFirstAhaSeen(): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(GARMIN_FIRST_AHA_SEEN_KEY, 'true')
+}

--- a/v0/lib/garminFirstAhaTypes.ts
+++ b/v0/lib/garminFirstAhaTypes.ts
@@ -1,0 +1,108 @@
+export type GarminFirstAhaStatus = 'ready' | 'partial' | 'insufficient_data' | 'error'
+
+export type RunnerTypeId =
+  | 'new_or_low_data_runner'
+  | 'building_consistency'
+  | 'consistent_base_builder'
+  | 'overreaching_risk'
+  | 'race_focused'
+
+export type GuardrailLevel = 'green' | 'yellow' | 'red'
+
+export type StarterDayType =
+  | 'easy_run'
+  | 'long_run'
+  | 'recovery'
+  | 'rest'
+  | 'strength'
+  | 'walk_run'
+
+export type StarterIntensity = 'easy' | 'moderate' | 'hard' | 'rest'
+
+export interface GarminFirstAhaRunInput {
+  completedAt: string
+  durationSeconds: number | null
+  distanceMeters: number | null
+  averageHeartRate: number | null
+}
+
+export interface GarminFirstAhaWellnessDay {
+  date: string
+  hrv: number | null
+  sleepScore: number | null
+  restingHr: number | null
+  stress: number | null
+}
+
+export interface GarminFirstAhaResult {
+  status: GarminFirstAhaStatus
+  generatedAt: string
+  dataWindow: {
+    activitiesDays: number
+    wellnessDays?: number
+  }
+  profile: {
+    runnerType: string
+    headline: string
+    summaryBullets: string[]
+    confidence: 'high' | 'medium' | 'low'
+  }
+  signals: {
+    consistency: {
+      runsLast14Days: number
+      runsLast28Days: number
+      weeklyPatternLabel: string
+    }
+    load: {
+      weeklyDistanceTrend?: string
+      acwrLabel?: 'low' | 'stable' | 'elevated' | 'unknown'
+      longestRunLabel?: string
+    }
+    intensity: {
+      label: string
+      easyShare?: number
+      hardShare?: number
+      source: 'heart_rate' | 'pace' | 'mixed' | 'insufficient'
+    }
+    recovery?: {
+      readinessLabel: string
+      availableSignals: string[]
+      missingSignals: string[]
+    }
+  }
+  guardrails: {
+    level: GuardrailLevel
+    message: string
+    reasons: string[]
+  }
+  starterPlan: {
+    title: string
+    rationale: string
+    days: Array<{
+      date: string
+      type: StarterDayType
+      label: string
+      target?: string
+      intensity: StarterIntensity
+      purpose: string
+    }>
+  }
+  recommendedChallenge: {
+    id: string
+    title: string
+    reason: string
+    fitScoreLabel: string
+  }
+  disclaimers: string[]
+}
+
+export const RUNNER_TYPE_LABELS: Record<RunnerTypeId, string> = {
+  new_or_low_data_runner: 'Getting started',
+  building_consistency: 'Building consistency',
+  consistent_base_builder: 'Base-building runner',
+  overreaching_risk: 'Recovery-focused runner',
+  race_focused: 'Fitness-focused runner',
+}
+
+export const MEDICAL_DISCLAIMER =
+  'This is coaching guidance, not medical advice. Stop and seek professional help if you feel pain or dizziness.'

--- a/v0/lib/server/garmin-first-aha-service.ts
+++ b/v0/lib/server/garmin-first-aha-service.ts
@@ -1,0 +1,121 @@
+import 'server-only'
+
+import { buildGarminFirstAhaResult } from '@/lib/garminFirstAhaBuilder'
+import type { GarminFirstAhaResult } from '@/lib/garminFirstAhaTypes'
+import { getGarminOAuthState } from '@/lib/server/garmin-oauth-store'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+interface GarminRunRow {
+  completed_at: string
+  duration: number | null
+  distance: number | null
+  heart_rate: number | null
+}
+
+interface GarminDailyRow {
+  date: string
+  hrv: number | null
+  sleep_score: number | null
+  resting_hr: number | null
+  stress: number | null
+}
+
+function shiftIsoDate(dateIso: string, deltaDays: number): string {
+  const base = Date.parse(`${dateIso}T00:00:00.000Z`)
+  const dayMs = 24 * 60 * 60 * 1000
+  return new Date(base + deltaDays * dayMs).toISOString().slice(0, 10)
+}
+
+export async function generateGarminFirstAha(userId: number): Promise<GarminFirstAhaResult> {
+  const oauthState = await getGarminOAuthState(userId)
+  if (!oauthState) {
+    return {
+      status: 'error',
+      generatedAt: new Date().toISOString(),
+      dataWindow: { activitiesDays: 28 },
+      profile: {
+        runnerType: 'Unavailable',
+        headline: 'Garmin connection required',
+        summaryBullets: ['Connect Garmin to generate your first running profile.'],
+        confidence: 'low',
+      },
+      signals: {
+        consistency: {
+          runsLast14Days: 0,
+          runsLast28Days: 0,
+          weeklyPatternLabel: 'No Garmin runs synced yet',
+        },
+        load: { acwrLabel: 'unknown' },
+        intensity: {
+          label: 'No intensity data',
+          source: 'insufficient',
+        },
+      },
+      guardrails: {
+        level: 'yellow',
+        message: 'Connect Garmin and sync activities before building a starter plan.',
+        reasons: ['No Garmin connection found'],
+      },
+      starterPlan: {
+        title: 'Starter block unavailable',
+        rationale: 'Sync Garmin activities first.',
+        days: [],
+      },
+      recommendedChallenge: {
+        id: 'start-running',
+        title: 'Start Running Challenge',
+        reason: 'Available after your first Garmin sync.',
+        fitScoreLabel: 'Pending data',
+      },
+      disclaimers: ['Connect Garmin and try again after your activities sync.'],
+    }
+  }
+
+  const admin = createAdminClient()
+  const endDate = new Date().toISOString().slice(0, 10)
+  const startDate = shiftIsoDate(endDate, -27)
+  const profileId = oauthState.profileId ?? null
+
+  const [runsQuery, dailyQuery] = await Promise.all([
+    profileId
+      ? admin
+          .from('runs')
+          .select('completed_at,duration,distance,heart_rate')
+          .eq('profile_id', profileId)
+          .gte('completed_at', `${startDate}T00:00:00.000Z`)
+          .order('completed_at', { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+    admin
+      .from('garmin_daily_metrics')
+      .select('date,hrv,sleep_score,resting_hr,stress')
+      .eq('user_id', userId)
+      .gte('date', startDate)
+      .order('date', { ascending: true }),
+  ])
+
+  if ('error' in runsQuery && runsQuery.error) {
+    throw new Error(runsQuery.error.message)
+  }
+  if (dailyQuery.error) {
+    throw new Error(dailyQuery.error.message)
+  }
+
+  const runs = ((runsQuery.data ?? []) as GarminRunRow[])
+    .filter((run) => typeof run.completed_at === 'string')
+    .map((run) => ({
+      completedAt: run.completed_at,
+      durationSeconds: run.duration,
+      distanceMeters: run.distance != null ? Math.round(Number(run.distance) * 1000) : null,
+      averageHeartRate: run.heart_rate,
+    }))
+
+  const wellnessDays = ((dailyQuery.data ?? []) as GarminDailyRow[]).map((row) => ({
+    date: row.date,
+    hrv: row.hrv,
+    sleepScore: row.sleep_score,
+    restingHr: row.resting_hr,
+    stress: row.stress,
+  }))
+
+  return buildGarminFirstAhaResult({ runs, wellnessDays, endDate })
+}

--- a/v0/lib/server/garmin-first-aha-service.ts
+++ b/v0/lib/server/garmin-first-aha-service.ts
@@ -2,7 +2,7 @@ import 'server-only'
 
 import { buildGarminFirstAhaResult } from '@/lib/garminFirstAhaBuilder'
 import type { GarminFirstAhaResult } from '@/lib/garminFirstAhaTypes'
-import { getGarminOAuthState } from '@/lib/server/garmin-oauth-store'
+import type { GarminOAuthState } from '@/lib/server/garmin-oauth-store'
 import { createAdminClient } from '@/lib/supabase/admin'
 
 interface GarminRunRow {
@@ -26,51 +26,53 @@ function shiftIsoDate(dateIso: string, deltaDays: number): string {
   return new Date(base + deltaDays * dayMs).toISOString().slice(0, 10)
 }
 
-export async function generateGarminFirstAha(userId: number): Promise<GarminFirstAhaResult> {
-  const oauthState = await getGarminOAuthState(userId)
-  if (!oauthState) {
-    return {
-      status: 'error',
-      generatedAt: new Date().toISOString(),
-      dataWindow: { activitiesDays: 28 },
-      profile: {
-        runnerType: 'Unavailable',
-        headline: 'Garmin connection required',
-        summaryBullets: ['Connect Garmin to generate your first running profile.'],
-        confidence: 'low',
+export function buildUnavailableGarminFirstAha(): GarminFirstAhaResult {
+  return {
+    status: 'error',
+    generatedAt: new Date().toISOString(),
+    dataWindow: { activitiesDays: 28 },
+    profile: {
+      runnerType: 'Unavailable',
+      headline: 'Garmin connection required',
+      summaryBullets: ['Connect Garmin to generate your first running profile.'],
+      confidence: 'low',
+    },
+    signals: {
+      consistency: {
+        runsLast14Days: 0,
+        runsLast28Days: 0,
+        weeklyPatternLabel: 'No Garmin runs synced yet',
       },
-      signals: {
-        consistency: {
-          runsLast14Days: 0,
-          runsLast28Days: 0,
-          weeklyPatternLabel: 'No Garmin runs synced yet',
-        },
-        load: { acwrLabel: 'unknown' },
-        intensity: {
-          label: 'No intensity data',
-          source: 'insufficient',
-        },
+      load: { acwrLabel: 'unknown' },
+      intensity: {
+        label: 'No intensity data',
+        source: 'insufficient',
       },
-      guardrails: {
-        level: 'yellow',
-        message: 'Connect Garmin and sync activities before building a starter plan.',
-        reasons: ['No Garmin connection found'],
-      },
-      starterPlan: {
-        title: 'Starter block unavailable',
-        rationale: 'Sync Garmin activities first.',
-        days: [],
-      },
-      recommendedChallenge: {
-        id: 'start-running',
-        title: 'Start Running Challenge',
-        reason: 'Available after your first Garmin sync.',
-        fitScoreLabel: 'Pending data',
-      },
-      disclaimers: ['Connect Garmin and try again after your activities sync.'],
-    }
+    },
+    guardrails: {
+      level: 'yellow',
+      message: 'Connect Garmin and sync activities before building a starter plan.',
+      reasons: ['No Garmin connection found'],
+    },
+    starterPlan: {
+      title: 'Starter block unavailable',
+      rationale: 'Sync Garmin activities first.',
+      days: [],
+    },
+    recommendedChallenge: {
+      id: 'start-running',
+      title: 'Start Running Challenge',
+      reason: 'Available after your first Garmin sync.',
+      fitScoreLabel: 'Pending data',
+    },
+    disclaimers: ['Connect Garmin and try again after your activities sync.'],
   }
+}
 
+export async function generateGarminFirstAha(
+  userId: number,
+  oauthState: GarminOAuthState
+): Promise<GarminFirstAhaResult> {
   const admin = createAdminClient()
   const endDate = new Date().toISOString().slice(0, 10)
   const startDate = shiftIsoDate(endDate, -27)


### PR DESCRIPTION
## Summary
- Implements Garmin First Aha v1 from `docs/superpowers/plans/2026-07-01-garmin-first-aha.md`: deterministic profile, guardrails, 14-day starter block, and one challenge recommendation.
- Adds `GET /api/garmin/first-aha` plus `/garmin/first-aha` coach-style UI with loading, ready, partial, insufficient, and error states.
- Redirects first successful Garmin OAuth callback to First Aha (localStorage seen flag); wires accept-plan and start-challenge actions with active-plan replace confirmation.

## Scope vs plan
**Implemented (v1 immediate):** all 5 build stories, definition-of-done items, and recommended implementation order.

**Deferred to v1.1+ (explicitly out of immediate v1):**
- Server-persisted "seen" flag (uses localStorage for now)
- Sync-pending polling / refresh-after-sync UX
- Dedicated challenge templates (easy-run discipline, return to running, first consistent month, build base safely) — mapped to closest existing templates
- AI wording layer (logic is fully deterministic)
- Active-challenge switch UI (join API only; no explicit "keep current challenge" modal)

## Test plan
- [x] `npm run test -- lib/garminFirstAha.test.ts app/api/garmin/first-aha/route.test.ts` (12 passed)
- [x] `npm run type-check`
- [x] `npm run build`
- [ ] Manual: first Garmin connect redirects to `/garmin/first-aha`
- [ ] Manual: reconnect after skip goes to profile
- [ ] Manual: accept plan with existing active plan shows replace confirmation
- [ ] Manual: start recommended challenge enrolls via `/api/challenges`
- [ ] Manual: mobile layout check on First Aha screen


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Garmin “First Aha” experience after connecting a device, with a dedicated page, personalized starter plan, and recommended challenge.
  * Users can now review a readiness summary, safety guidance, and an early preview of the plan before accepting it.
  * The connection flow now sends returning users to the profile screen, while first-time users see the new onboarding experience.

* **Bug Fixes**
  * Improved handling for incomplete data so users still receive a usable result instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->