### PR TITLE
agents: refresh subagent model IDs to Sonnet 5

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: Code Reviewer
 description: Reviews implementation diffs for regressions, unrelated changes, removed tests, and security issues. Use after every implementation, before the done declaration.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 # Code Reviewer Agent — RunSmart

--- a/.claude/agents/director.md
+++ b/.claude/agents/director.md
@@ -1,7 +1,7 @@
 ---
 name: Director
 description: Session owner. Activates at the start of every coding session to confirm scope, sequence stories, and declare done. Use when starting any non-trivial task or when implementation has completed and needs a final quality gate.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 # Director Agent — RunSmart

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -1,7 +1,7 @@
 ---
 name: Product Manager
 description: Clarifies user value and acceptance criteria. Use when a task description is vague, when there is no clear success definition, or when proposed implementation doesn't map to a real user need.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 # Product Manager Agent — RunSmart

--- a/.claude/agents/qa-tdd.md
+++ b/.claude/agents/qa-tdd.md
@@ -1,7 +1,7 @@
 ---
 name: QA / TDD
 description: Defines test plans before implementation and verifies behavior after. Use before any implementation to define what tests are needed, and after implementation to run tests and report results.
-model: claude-sonnet-4-6
+model: claude-sonnet-5
 ---
 
 # QA / TDD Agent — RunSmart


### PR DESCRIPTION
Part of the July 2026 model-routing refresh (Agentic OS `GLOBAL-TOOL-USAGE.md`, `DECISIONS.md` 2026-07-10).

## What changed
The four Sonnet-tier subagents were pinned to the stale `claude-sonnet-4-6`. Updated to the current `claude-sonnet-5`:

- `.claude/agents/qa-tdd.md`
- `.claude/agents/code-reviewer.md`
- `.claude/agents/product-manager.md`
- `.claude/agents/director.md`

`architect.md` (`claude-opus-4-8`) and `scrum-master.md` (`claude-haiku-4-5-20251001`) were already on current IDs and are untouched.

## Scope
Role→tier mapping is unchanged — this is only a stale-ID refresh. Deeper per-agent re-routing (e.g. cross-vendor reviewer steps) is a separate follow-up per the decision log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configured AI model for code review, direction, product management, and QA workflows.
  * These workflows now use the latest configured Sonnet model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->