### PR TITLE
Fix web return path for iOS registration

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,6 +4,11 @@ Reusable lessons for Claude Code, Codex, Cursor, and other agents.
 
 ## Active Lessons
 
+### Lesson: Mobile Auth Links Need One Verified Cross-Layer Contract
+- Trigger: A native Supabase PKCE flow uses a hosted HTTPS callback.
+- Problem: A wrong AASA bundle ID, a redirected association domain, or server-side code exchange can each strand the same user while every individual component appears configured.
+- Future Rule: Test the exact team/bundle ID, canonical no-redirect AASA host, native associated domain, callback source marker, fixed custom-scheme fallback, and on-device PKCE exchange together.
+
 ### Lesson: Keep Agent OS Router Files Thin
 - Trigger: Installing or updating project instructions.
 - Problem: Long root instruction files waste tokens and reduce compliance.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -75,6 +75,20 @@ Land the stranded credential guard branch, add a production-default-off `GARMIN_
 
 ---
 
+## Completed Task — 2026-08-06 iOS registration return path
+
+As a runner who starts registration in iOS, an email/browser confirmation must return to RunSmart with the native Supabase session instead of stranding the runner on the website.
+
+- [x] Confirm the shipped iOS team and bundle identity.
+- [x] Add red-first tests for AASA and native-return behavior.
+- [x] Correct the AASA app identity and narrow it to auth paths.
+- [x] Return allowlisted code/error fields to a fixed custom-scheme callback when Universal Links do not intercept.
+- [x] Keep ordinary web callback exchange unchanged.
+- [x] Pass 5 focused tests, TypeScript type-check, targeted lint, and diff checks.
+- [ ] Merge and deploy before or alongside the paired native release.
+
+---
+
 ## Next Session — Story 1: Today Content Inventory + Preservation Map
 
 Spec: docs/specs/2026-05-12-today-command-center.md (read this first)

--- a/v0/app/auth/callback/association.test.ts
+++ b/v0/app/auth/callback/association.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('RunSmart universal-link association', () => {
+  it('advertises the shipped iOS bundle and only the auth return surface', () => {
+    const association = JSON.parse(
+      readFileSync(
+        join(process.cwd(), 'public/.well-known/apple-app-site-association'),
+        'utf8',
+      ),
+    )
+    const details = association.applinks.details[0]
+
+    expect(details.appID).toBe('8VC4R5M425.com.runsmart.lite')
+    expect(details.paths).toContain('/auth/callback')
+    expect(details.paths).not.toContain('/')
+  })
+})

--- a/v0/app/auth/callback/native-return.test.ts
+++ b/v0/app/auth/callback/native-return.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { nativeReturnURL } from './native-return'
+import { GET } from './route'
+
+describe('nativeReturnURL', () => {
+  it('returns an iOS PKCE code to the fixed RunSmart callback', () => {
+    const request = new URL(
+      'https://www.runsmart-ai.com/auth/callback?source=ios&code=pkce-code&type=signup',
+    )
+
+    expect(nativeReturnURL(request)?.toString()).toBe(
+      'runsmart://auth/callback?code=pkce-code&type=signup',
+    )
+  })
+
+  it('returns Supabase callback errors so the app can recover visibly', () => {
+    const request = new URL(
+      'https://www.runsmart-ai.com/auth/callback?source=ios&error=access_denied&error_code=otp_expired&error_description=Email+link+expired',
+    )
+
+    expect(nativeReturnURL(request)?.toString()).toBe(
+      'runsmart://auth/callback?error=access_denied&error_code=otp_expired&error_description=Email+link+expired',
+    )
+  })
+
+  it('does not change ordinary web callbacks or accept another source', () => {
+    expect(
+      nativeReturnURL(
+        new URL('https://www.runsmart-ai.com/auth/callback?code=web-code'),
+      ),
+    ).toBeNull()
+    expect(
+      nativeReturnURL(
+        new URL(
+          'https://www.runsmart-ai.com/auth/callback?source=https://attacker.example&code=web-code',
+        ),
+      ),
+    ).toBeNull()
+  })
+})
+
+describe('iOS callback route fallback', () => {
+  it('redirects to the app before attempting a server-side PKCE exchange', async () => {
+    const response = await GET(
+      new Request(
+        'https://www.runsmart-ai.com/auth/callback?source=ios&code=pkce-code&type=signup',
+      ),
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe(
+      'runsmart://auth/callback?code=pkce-code&type=signup',
+    )
+  })
+})

--- a/v0/app/auth/callback/native-return.ts
+++ b/v0/app/auth/callback/native-return.ts
@@ -1,0 +1,22 @@
+const IOS_CALLBACK_SOURCE = 'ios'
+const IOS_CALLBACK_URL = 'runsmart://auth/callback'
+const FORWARDED_PARAMETERS = [
+  'code',
+  'type',
+  'error',
+  'error_code',
+  'error_description',
+] as const
+
+export function nativeReturnURL(requestURL: URL): URL | null {
+  if (requestURL.searchParams.get('source') !== IOS_CALLBACK_SOURCE) {
+    return null
+  }
+
+  const nativeURL = new URL(IOS_CALLBACK_URL)
+  for (const name of FORWARDED_PARAMETERS) {
+    const value = requestURL.searchParams.get(name)
+    if (value) nativeURL.searchParams.set(name, value)
+  }
+  return nativeURL
+}

--- a/v0/app/auth/callback/route.ts
+++ b/v0/app/auth/callback/route.ts
@@ -1,11 +1,21 @@
 import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
+import { nativeReturnURL } from './native-return'
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const token_hash = requestUrl.searchParams.get('token_hash')
   const type = requestUrl.searchParams.get('type')
+
+  // A native PKCE verifier lives on the device, so the web server cannot
+  // exchange an iOS-originated code. Universal Links normally open the app
+  // before this route runs; this fixed custom-scheme redirect is the fallback
+  // when the association has not been cached by iOS yet.
+  const nativeURL = nativeReturnURL(requestUrl)
+  if (nativeURL) {
+    return NextResponse.redirect(nativeURL)
+  }
 
   const supabase = await createClient()
 

--- a/v0/public/.well-known/apple-app-site-association
+++ b/v0/public/.well-known/apple-app-site-association
@@ -3,12 +3,11 @@
     "apps": [],
     "details": [
       {
-        "appID": "8VC4R5M425.com.runsmart.coach",
+        "appID": "8VC4R5M425.com.runsmart.lite",
         "paths": [
           "/auth/callback",
           "/auth/callback/*",
-          "/auth/update-password",
-          "/"
+          "/auth/update-password"
         ]
       }
     ]


### PR DESCRIPTION
## Outcome

Supabase callbacks that originated in RunSmart iOS return to the app instead of being stranded on the website.

## Changes

- correct the AASA identity to shipped app 8VC4R5M425.com.runsmart.lite
- scope Universal Links to auth paths instead of the website root
- return explicitly marked iOS callbacks to the fixed runsmart auth callback before server-side PKCE exchange
- forward only allowlisted Supabase code and error fields
- leave normal web callbacks unchanged

## Validation

- callback and AASA tests: 5 passed
- TypeScript type-check passed
- targeted ESLint passed
- diff and JSON validation passed

## Deployment

Deploy this before or alongside the paired iOS PR. Confirm the Supabase redirect allowlist accepts https://www.runsmart-ai.com/auth/callback*.