### PR TITLE
Fix live iOS association route

### DIFF
--- a/v0/app/.well-known/apple-app-site-association/route.ts
+++ b/v0/app/.well-known/apple-app-site-association/route.ts
@@ -5,8 +5,8 @@ const AASA = {
     apps: [],
     details: [
       {
-        appID: '8VC4R5M425.com.runsmart.coach',
-        paths: ['/auth/callback', '/auth/callback/*', '/auth/update-password', '/'],
+        appID: '8VC4R5M425.com.runsmart.lite',
+        paths: ['/auth/callback', '/auth/callback/*', '/auth/update-password'],
       },
     ],
   },

--- a/v0/app/auth/callback/association.test.ts
+++ b/v0/app/auth/callback/association.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { GET } from '../../.well-known/apple-app-site-association/route'
 
 describe('RunSmart universal-link association', () => {
   it('advertises the shipped iOS bundle and only the auth return surface', () => {
@@ -10,6 +11,16 @@ describe('RunSmart universal-link association', () => {
         'utf8',
       ),
     )
+    const details = association.applinks.details[0]
+
+    expect(details.appID).toBe('8VC4R5M425.com.runsmart.lite')
+    expect(details.paths).toContain('/auth/callback')
+    expect(details.paths).not.toContain('/')
+  })
+
+  it('serves the shipped iOS bundle from the Next.js route', async () => {
+    const response = await GET()
+    const association = await response.json()
     const details = association.applinks.details[0]
 
     expect(details.appID).toBe('8VC4R5M425.com.runsmart.lite')


### PR DESCRIPTION
## Summary
- serve the shipped `com.runsmart.lite` bundle ID from the Next.js AASA route
- remove the overly broad root path
- test the runtime route as well as the public artifact

## Verification
- 6 focused auth/association tests passed
- TypeScript type-check passed
- targeted ESLint passed with only the existing route-ignore warning

Follow-up to #120 after production verification found the route handler overriding the public file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS app association settings to target the correct app.
  * Limited app link handling to authentication callback and password-update paths.
  * Added validation to ensure the association response advertises the expected app and supported path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->